### PR TITLE
docs: harden pancake guidance and content checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Run content baseline
         run: make check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 ## Repository purpose
 
-`garethpaul/fantastic-pancake` is a public sample, documentation, or utility project. a repo about pancakes
+`garethpaul/fantastic-pancake` is a content-only collection of practical
+pancake notes covering preparation, troubleshooting, serving, allergens, and
+food safety. It intentionally has no application or dependency scaffold.
 
 ## Project structure
 
@@ -42,6 +44,8 @@
 - The scan did not identify production authentication, payment, or secret-management code. Treat future additions in those areas as security-sensitive.
 - Food-safety guidance should cite official sources and avoid vague storage or serving claims.
 - Allergen guidance should stay tied to official sources and should not promise allergen-free preparation without controlled ingredients and surfaces.
+- Raw flour, eggs, and batter must be described as potentially unsafe to taste before cooking; cleanup guidance should remain tied to FDA and CDC sources.
+- Preserve concrete time and temperature thresholds for storage, event holding, and reheating, and update their official sources when guidance changes.
 - Run `make check` before pushing content or documentation changes.
 - Keep the no-scaffold contract in place until there is a concrete publishing plan for an app or static site.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Repository purpose
+
+`garethpaul/fantastic-pancake` is a public sample, documentation, or utility project. a repo about pancakes
+
+## Project structure
+
+- `Makefile` - repository verification targets
+- `scripts` - baseline checks and helper scripts
+- `docs` - plans, notes, and generated README assets
+
+## Development commands
+
+- Install dependencies: no repository-specific install command is documented.
+- Full baseline: `make check`
+- Lint/static checks: `make lint`
+- Tests: `make test`
+- Build: `make build`
+- If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
+
+## Coding conventions
+
+- Follow the existing file layout and naming used by the checked-in sample.
+
+## Testing guidance
+
+- No dedicated test files were detected; treat `make check` as the minimum baseline.
+- Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
+- Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
+
+## PR / change guidance
+
+- Keep diffs focused on the requested repository and avoid unrelated modernization or formatting churn.
+- Preserve public APIs, sample behavior, file formats, and documented environment variables unless the task explicitly changes them.
+- Update tests, README notes, or docs/plans when behavior, security posture, or validation commands change.
+- Call out skipped platform validation, legacy toolchain assumptions, and any risky files touched in the final summary.
+
+## Safety and gotchas
+
+- No required secret or credential file was identified in the repository scan. If you add integrations later, keep secrets out of git.
+- The scan did not identify production authentication, payment, or secret-management code. Treat future additions in those areas as security-sensitive.
+- Food-safety guidance should cite official sources and avoid vague storage or serving claims.
+- Allergen guidance should stay tied to official sources and should not promise allergen-free preparation without controlled ingredients and surfaces.
+- Run `make check` before pushing content or documentation changes.
+- Keep the no-scaffold contract in place until there is a concrete publishing plan for an app or static site.
+
+## Agent workflow
+
+1. Inspect the README, Makefile, manifests, and the files directly related to the request.
+2. Make the smallest source or docs change that satisfies the task; avoid generated, vendored, or local-environment files unless required.
+3. Run the narrowest useful validation first, then `make check` or the documented package/platform gate when available.
+4. If a required SDK, service credential, or external runtime is unavailable, record the skipped command and why.
+5. Summarize changed files, commands run, and remaining risks or follow-up validation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 - Added FDA- and CDC-backed raw batter handling and cleanup guidance.
 - Added a pinned, least-privilege GitHub Actions workflow that runs the content
-  and no-scaffold baseline for pushes and pull requests.
+  and no-scaffold baseline for pushes and pull requests without persisting
+  checkout credentials.
 - Extended the checker and documentation to keep hosted verification required.
 
 ## 2026-06-09

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ and reheating thresholds.
 The `make lint`, `make test`, and `make build` aliases run the same content
 baseline while this repository has no narrower installed gates.
 GitHub Actions runs `make check` for pushes and pull requests with read-only
-repository permissions.
+repository permissions and does not persist checkout credentials.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,8 @@ Helpful reports include:
 - Food allergy and event-serving guidance can affect reader safety. Keep allergen claims source-backed and avoid promising allergen-free food without controlled ingredients, utensils, and prep surfaces.
 - Mix-ins and topping guidance should preserve clear allergen labels and separate serving-utensil language for shared pancake bars.
 - GitHub Actions runs the content and no-scaffold baseline with read-only
-  repository permissions before changes land.
+  repository permissions and without persisted checkout credentials before
+  changes land.
 
 
 ## Dependency and Supply Chain Security

--- a/VISION.md
+++ b/VISION.md
@@ -50,7 +50,8 @@ Current baseline:
   allergen-free claims tied to official source guidance.
 - `make lint`, `make test`, and `make build` run the same content baseline
   while no narrower gates are installed.
-- GitHub Actions runs the local content baseline for pushes and pull requests.
+- GitHub Actions runs the local content baseline for pushes and pull requests
+  without persisting checkout credentials.
 
 Next priorities:
 

--- a/docs/plans/2026-06-10-hosted-content-checks.md
+++ b/docs/plans/2026-06-10-hosted-content-checks.md
@@ -12,8 +12,8 @@ default-branch pushes had no hosted verification.
 
 - Added a least-privilege GitHub Actions workflow for pushes, pull requests,
   and manual runs.
-- Pinned the checkout action by commit and bounded runs with cancellation and
-  a five-minute timeout.
+- Pinned the checkout action by commit, disabled persisted checkout credentials,
+  and bounded runs with cancellation and a five-minute timeout.
 - Extended the local baseline and project documentation to keep hosted checks
   part of the repository contract.
 

--- a/docs/plans/2026-06-12-pancake-batch-scaling-table.md
+++ b/docs/plans/2026-06-12-pancake-batch-scaling-table.md
@@ -39,3 +39,20 @@ working and can easily scale salt or leavening inconsistently.
 - `make build`
 - `make check`
 - `git diff --check`
+
+## Work Completed
+
+- Added exact 1x, 2x, and 4x quantities for flour, baking powder, sugar, salt,
+  milk, eggs, and melted butter or neutral oil.
+- Kept the existing 1/4 cup portion assumption visible and recommended two
+  freshly mixed 16-pancake bowls instead of one long-waiting 32-pancake bowl.
+- Updated the project documentation and extended the offline content baseline.
+
+## Verification Completed
+
+- `sh -n scripts/check-baseline.sh`, all four Make gates, and
+  `git diff --check` passed locally after integration into PR #4.
+- Implementation push run `27392180169` and pull-request run `27392182290`
+  passed at commit `9ab88d98d890f0a3777792e03f6ba1e7f078bcaf`.
+- Post-merge push run `27392192010` and CodeQL run `27402319817` passed at
+  default-branch merge commit `f9d74664aae853af3b37fd0a4ab887234c863caa`.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -233,15 +233,39 @@ if [ "$bullet_count" -lt 20 ]; then
   exit 1
 fi
 
-if ! grep -Fq "| Ingredient | About 8 | About 16 | About 32 |" "$ROOT_DIR/pancakes.md" ||
-  ! grep -Fq "| Flour | 1 cup | 2 cups | 4 cups |" "$ROOT_DIR/pancakes.md" ||
-  ! grep -Fq "| Baking powder | 2 teaspoons | 4 teaspoons | 8 teaspoons |" "$ROOT_DIR/pancakes.md" ||
-  ! grep -Fq "| Salt | 1/4 teaspoon | 1/2 teaspoon | 1 teaspoon |" "$ROOT_DIR/pancakes.md" ||
-  ! grep -Fq "| Eggs | 1 | 2 | 4 |" "$ROOT_DIR/pancakes.md" ||
-  ! grep -Fq "two separate sets of the 16-pancake quantities" "$ROOT_DIR/pancakes.md"; then
-  printf '%s\n' "pancakes.md must keep the ratio-aligned batch scaling table and fresh-bowl guidance." >&2
-  exit 1
-fi
+python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+lines = content.splitlines()
+header = "| Ingredient | About 8 | About 16 | About 32 |"
+expected = [
+    ["Flour", "1 cup", "2 cups", "4 cups"],
+    ["Baking powder", "2 teaspoons", "4 teaspoons", "8 teaspoons"],
+    ["Sugar", "1 tablespoon", "2 tablespoons", "4 tablespoons"],
+    ["Salt", "1/4 teaspoon", "1/2 teaspoon", "1 teaspoon"],
+    ["Milk", "1 cup", "2 cups", "4 cups"],
+    ["Eggs", "1", "2", "4"],
+    ["Melted butter or neutral oil", "2 tablespoons", "4 tablespoons", "8 tablespoons"],
+]
+
+try:
+    start = lines.index(header)
+except ValueError:
+    raise SystemExit("pancakes.md must keep the batch scaling table header.")
+
+rows = []
+for line in lines[start + 2 :]:
+    if not line.startswith("|"):
+        break
+    rows.append([cell.strip() for cell in line.strip("|").split("|")])
+
+if rows != expected:
+    raise SystemExit("pancakes.md must keep every ratio-aligned batch scaling quantity.")
+if "two separate sets of the 16-pancake quantities" not in content:
+    raise SystemExit("pancakes.md must keep the fresh-bowl scaling guidance.")
+PY
 
 if grep -Eq '^(---|### \*\*)' "$ROOT_DIR/pancakes.md"; then
   printf '%s\n' "pancakes.md should use clean Markdown headings, not placeholder separators." >&2
@@ -411,10 +435,31 @@ if ! grep -Fq "status: completed" "$CI_PLAN" ||
   exit 1
 fi
 
-if ! grep -Fq "status: completed" "$BATCH_SCALING_PLAN" ||
-  ! grep -Fq "make check" "$BATCH_SCALING_PLAN"; then
-  printf '%s\n' "The batch scaling plan must remain completed and verifiable." >&2
-  exit 1
-fi
+python3 - "$BATCH_SCALING_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "all four Make gates",
+    "push run `27392180169`",
+    "pull-request run `27392182290`",
+    "push run `27392192010`",
+    "CodeQL run `27402319817`",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "The batch scaling plan must remain completed with actual verification recorded."
+    )
+PY
 
 printf '%s\n' "fantastic-pancake content baseline checks passed."

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -104,13 +104,94 @@ if ! grep -Fq "lint: check" "$ROOT_DIR/Makefile" ||
 fi
 
 if ! grep -Fq "workflow_dispatch:" "$CI_WORKFLOW" ||
-  ! grep -Fq "contents: read" "$CI_WORKFLOW" ||
   ! grep -Fq "cancel-in-progress: true" "$CI_WORKFLOW" ||
   ! grep -Fq "runs-on: ubuntu-24.04" "$CI_WORKFLOW" ||
   ! grep -Fq "timeout-minutes: 5" "$CI_WORKFLOW" ||
-  ! grep -Fq "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" "$CI_WORKFLOW" ||
   ! grep -Fq "run: make check" "$CI_WORKFLOW"; then
   printf '%s\n' "GitHub Actions must keep the bounded, least-privilege content check contract." >&2
+  exit 1
+fi
+
+if [ "$(grep -Ec '^[[:space:]]+(-[[:space:]]+)?uses: actions/checkout@' "$CI_WORKFLOW")" -ne 1 ]; then
+  printf '%s\n' "GitHub Actions must contain exactly one checkout step." >&2
+  exit 1
+fi
+
+if ! awk '
+  function finish_step() {
+    if (checkout) {
+      checkout_count++
+      if (persist_credentials) {
+        secure_checkout_count++
+      }
+    }
+    checkout = 0
+    with_block = 0
+    persist_credentials = 0
+  }
+
+  /^      - / {
+    finish_step()
+  }
+
+  /^        uses: actions\/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10([[:space:]]+#.*)?$/ {
+    checkout = 1
+  }
+
+  /^      - uses: actions\/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10([[:space:]]+#.*)?$/ {
+    checkout = 1
+  }
+
+  checkout && /^        with:$/ {
+    with_block = 1
+  }
+
+  checkout && with_block && /^          persist-credentials: false$/ {
+    persist_credentials = 1
+  }
+
+  END {
+    finish_step()
+    exit !(checkout_count == 1 && secure_checkout_count == 1)
+  }
+' "$CI_WORKFLOW"; then
+  printf '%s\n' "The pinned checkout step must disable persisted credentials." >&2
+  exit 1
+fi
+
+if ! awk '
+  /^permissions:$/ {
+    permissions_count++
+    in_permissions = 1
+    next
+  }
+
+  in_permissions && /^[^[:space:]]/ {
+    in_permissions = 0
+  }
+
+  in_permissions && /^  contents: read$/ {
+    contents_read++
+    next
+  }
+
+  in_permissions && /^  [[:alnum:]_-]+:/ {
+    unexpected_permission++
+  }
+
+  END {
+    exit !(permissions_count == 1 && contents_read == 1 && unexpected_permission == 0)
+  }
+' "$CI_WORKFLOW" ||
+  grep -Eq '^[[:space:]]+permissions:' "$CI_WORKFLOW" ||
+  grep -Eq '^[[:space:]]*permissions:[[:space:]]*write-all([[:space:]]*(#.*)?)?$' "$CI_WORKFLOW" ||
+  grep -Eq '^[[:space:]]+[[:alnum:]_-]+:[[:space:]]*write([[:space:]]*(#.*)?)?$' "$CI_WORKFLOW"; then
+  printf '%s\n' "GitHub Actions must grant only top-level read access to repository contents." >&2
+  exit 1
+fi
+
+if ! grep -Fq "does not persist checkout credentials" "$ROOT_DIR/README.md"; then
+  printf '%s\n' "README must document the credential-free checkout boundary." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

The content-only pancake guide now has explicit contributor guardrails,
credential-free hosted checks, source-backed food-safety boundaries, and a
fully validated batch-scaling table for about 8, 16, and 32 pancakes.

## Baseline

The pre-change constraints and motivation are captured in the Summary and existing supporting sections.

## Improvements

- Document the repository's intentional no-scaffold boundary and reject source
  trees, manifests, and dependency files until a publishing plan exists.
- Preserve FDA/CDC raw-batter guidance plus concrete storage, holding,
  reheating, and allergen rules.
- Disable persisted checkout credentials and structurally enforce one pinned
  checkout plus one top-level read-only permissions block.
- Add exact 1x, 2x, and 4x quantities for every ingredient in the basic ratio,
  with fresh-bowl guidance for larger service.
- Parse the complete Markdown scaling table so incorrect sugar, milk, fat, or
  other quantities cannot evade representative spot checks.
- Require the completed plan to contain actual local, canonical workflow, and
  CodeQL evidence rather than a future-tense checklist or stale run tokens.

## Validation

- `make check`, `make lint`, `make test`, and `make build`.
- `sh -n scripts/check-baseline.sh` and `git diff --check`.
- Workflow-policy mutations reject insecure checkout and permission changes.
- Five scaling/evidence mutations rejected: incorrect sugar, milk, or fat;
  stale completion token; and pending evidence retaining an old run ID.
- Push run `27408604385` and pull-request run `27408606042` passed at exact
  head `912706877873433c97717692b3b0fb4df4d25af7`.
- CodeQL run `27408604090` passed with zero open code-scanning alerts.

## Risk

- Food-safety and allergen guidance must continue to track authoritative
  public-health sources.
- The no-scaffold contract intentionally rejects application structure until a
  concrete audience and publishing format are defined.
- Older content PRs #1-#3 remain open and were not modified or closed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)

## Follow-Ups

No additional follow-up is introduced by this description-only normalization; existing monitoring and remaining-work notes remain authoritative.
