### PR TITLE
Add a reliable pancake batch scaling table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-12
+
+- Added an 8-, 16-, and 32-pancake scaling table tied to the basic ratio and
+  practical fresh-bowl guidance for the largest batch.
+- Extended the content baseline to preserve the scaled quantities and plan.
+
 ## 2026-06-10
 
 - Added FDA- and CDC-backed raw batter handling and cleanup guidance.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   sources when expanding event or leftover content.
 - Keep portioning and batch-size notes practical when expanding group cooking
   guidance.
+- Keep the batch scaling table aligned with the basic ratio and 1/4 cup yield.
 - Keep griddle heat and doneness notes practical when expanding method content.
 - Keep batter texture and resting notes concise when expanding method content.
 - Keep mix-ins and topping notes practical, clearly labeled, and tied to the

--- a/VISION.md
+++ b/VISION.md
@@ -5,8 +5,8 @@ Project overview and developer docs: [`README.md`](README.md)
 
 Fantastic Pancake is a lightweight repository about pancakes. It currently
 contains a simple `pancakes.md` outline covering a basic method, pancake types,
-basic ratio, portioning, batter consistency, tips, troubleshooting, traditions,
-mix-ins, toppings, and creative ideas.
+basic ratio, batch scaling, portioning, batter consistency, tips,
+troubleshooting, traditions, mix-ins, toppings, and creative ideas.
 
 The goal is to keep the repository as a small, readable content project rather
 than adding unnecessary application scaffolding.
@@ -30,6 +30,8 @@ Current baseline:
 - `pancakes.md` uses clean Markdown headings and enough specific bullets to
   avoid placeholder-only sections.
 - Basic ratio notes provide a practical starting formula before variations.
+- A batch scaling table keeps 8-, 16-, and 32-pancake quantities aligned with
+  the basic ratio and recommends freshly mixed bowls for the largest service.
 - Portioning and batch-size notes keep scoop sizes, spacing, and dry-mix prep
   practical for small or larger breakfasts.
 - Batter consistency and resting notes describe texture cues, small
@@ -61,6 +63,7 @@ Next priorities:
 - Keep allergen and food-safety guidance reviewed when expanding event content
 - Keep batch storage guidance concise and source-backed
 - Keep portioning guidance practical and tied to the basic ratio
+- Keep batch scaling quantities aligned with the basic ratio and stated yield
 - Keep batter texture notes practical and tied to the basic method
 - Keep mix-ins and topping guidance practical and tied to event-serving labels
 

--- a/docs/plans/2026-06-12-pancake-batch-scaling-table.md
+++ b/docs/plans/2026-06-12-pancake-batch-scaling-table.md
@@ -1,0 +1,41 @@
+---
+title: Pancake Batch Scaling Table
+date: 2026-06-12
+status: planned
+execution: content
+---
+
+## Context
+
+The guide gives a dependable ratio for about eight medium pancakes and tells
+readers to scale wet and dry ingredients together. It does not show the actual
+quantities for larger breakfasts, so readers must repeat the arithmetic while
+working and can easily scale salt or leavening inconsistently.
+
+## Goals
+
+- Add a compact table for batches of about 8, 16, and 32 medium pancakes.
+- Keep every quantity mathematically aligned with the existing basic ratio.
+- Recommend preparing the largest service as smaller freshly mixed bowls so
+  batter does not wait unnecessarily while pancakes cook.
+- Preserve the content-only repository boundary and existing safety guidance.
+
+## Implementation
+
+- Add `## Batch Scaling Table` next to the basic ratio in `pancakes.md`.
+- List flour, baking powder, sugar, salt, milk, eggs, and melted butter or oil
+  for one, two, and four times the base recipe.
+- Clarify that the yield assumes the existing 1/4 cup portion and that actual
+  yield varies with adjustment and scoop size.
+- Update README, VISION, and CHANGES to record the new content contract.
+- Extend `scripts/check-baseline.sh` to require the plan, heading, batch sizes,
+  representative scaled quantities, and fresh-bowl guidance.
+
+## Verification
+
+- `sh -n scripts/check-baseline.sh`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `git diff --check`

--- a/docs/plans/2026-06-12-pancake-batch-scaling-table.md
+++ b/docs/plans/2026-06-12-pancake-batch-scaling-table.md
@@ -1,7 +1,7 @@
 ---
 title: Pancake Batch Scaling Table
 date: 2026-06-12
-status: planned
+status: completed
 execution: content
 ---
 

--- a/pancakes.md
+++ b/pancakes.md
@@ -21,6 +21,25 @@ for breakfast, brunch, dessert, or community events.
 - Scale dry and wet ingredients together when cooking for a group, then adjust
   thickness after the batter rests.
 
+## Batch Scaling Table
+
+The amounts below assume the 1/4 cup portion used for medium pancakes. Final
+yield can vary slightly after consistency adjustments or a different scoop.
+
+| Ingredient | About 8 | About 16 | About 32 |
+| --- | ---: | ---: | ---: |
+| Flour | 1 cup | 2 cups | 4 cups |
+| Baking powder | 2 teaspoons | 4 teaspoons | 8 teaspoons |
+| Sugar | 1 tablespoon | 2 tablespoons | 4 tablespoons |
+| Salt | 1/4 teaspoon | 1/2 teaspoon | 1 teaspoon |
+| Milk | 1 cup | 2 cups | 4 cups |
+| Eggs | 1 | 2 | 4 |
+| Melted butter or neutral oil | 2 tablespoons | 4 tablespoons | 8 tablespoons |
+
+- For about 32 pancakes, measure two separate sets of the 16-pancake quantities
+  and mix those bowls in succession. Freshly mixed smaller bowls are easier to
+  handle and keep later batter from waiting through the entire first batch.
+
 ## Portioning and Batch Size
 
 - Use a 1/4 cup scoop for medium pancakes so the basic ratio yields about 8

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -14,6 +14,7 @@ PORTION_PLAN="$ROOT_DIR/docs/plans/2026-06-09-pancake-portioning-batch-size.md"
 MIX_INS_PLAN="$ROOT_DIR/docs/plans/2026-06-09-pancake-mix-ins-toppings.md"
 RAW_BATTER_PLAN="$ROOT_DIR/docs/plans/2026-06-10-raw-batter-safety.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-content-checks.md"
+BATCH_SCALING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pancake-batch-scaling-table.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -43,6 +44,7 @@ for path in \
   "docs/plans/2026-06-09-pancake-storage-reheating.md" \
   "docs/plans/2026-06-09-pancake-troubleshooting-section.md" \
   "docs/plans/2026-06-10-raw-batter-safety.md" \
+  "docs/plans/2026-06-12-pancake-batch-scaling-table.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
@@ -125,6 +127,7 @@ for heading in \
   "# Pancakes" \
   "## Basic Pancake Method" \
   "## Basic Pancake Ratio" \
+  "## Batch Scaling Table" \
   "## Portioning and Batch Size" \
   "## Batter Consistency and Resting" \
   "## Types of Pancakes" \
@@ -146,6 +149,16 @@ done
 bullet_count=$(grep -c '^- ' "$ROOT_DIR/pancakes.md")
 if [ "$bullet_count" -lt 20 ]; then
   printf '%s\n' "pancakes.md must keep enough specific content bullets." >&2
+  exit 1
+fi
+
+if ! grep -Fq "| Ingredient | About 8 | About 16 | About 32 |" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "| Flour | 1 cup | 2 cups | 4 cups |" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "| Baking powder | 2 teaspoons | 4 teaspoons | 8 teaspoons |" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "| Salt | 1/4 teaspoon | 1/2 teaspoon | 1 teaspoon |" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "| Eggs | 1 | 2 | 4 |" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "two separate sets of the 16-pancake quantities" "$ROOT_DIR/pancakes.md"; then
+  printf '%s\n' "pancakes.md must keep the ratio-aligned batch scaling table and fresh-bowl guidance." >&2
   exit 1
 fi
 
@@ -314,6 +327,12 @@ fi
 if ! grep -Fq "status: completed" "$CI_PLAN" ||
   ! grep -Fq "make check" "$CI_PLAN"; then
   printf '%s\n' "Hosted content checks plan must be completed and record verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$BATCH_SCALING_PLAN" ||
+  ! grep -Fq "make check" "$BATCH_SCALING_PLAN"; then
+  printf '%s\n' "The batch scaling plan must remain completed and verifiable." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- add an explicit 8-, 16-, and 32-pancake ingredient table aligned with the existing base ratio
- recommend mixing the largest service as two separate fresh bowls
- extend the content baseline and project documentation to preserve the scaling contract

## Verification

- `sh -n scripts/check-baseline.sh`
- `make lint`
- `make test`
- `make build`
- `make check`
- `git diff --check`
- intentional table-drift mutation rejected by `scripts/check-baseline.sh`
