### PR TITLE
docs: add first pancake calibration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-13
+
+- Added a first-pancake calibration sequence that separates heat corrections
+  from tablespoon-by-tablespoon batter adjustments.
+- Extended the content baseline to preserve the calibration order and completed
+  verification evidence.
+
 ## 2026-06-12
 
 - Added an 8-, 16-, and 32-pancake scaling table tied to the basic ratio and

--- a/README.md
+++ b/README.md
@@ -102,12 +102,16 @@ When the required SDK or runtime is unavailable, use static checks and source re
   guidance.
 - Keep the batch scaling table aligned with the basic ratio and 1/4 cup yield.
 - Keep griddle heat and doneness notes practical when expanding method content.
+- Keep first-pancake calibration tied to the 1/4 cup portion and one-variable
+  adjustments.
 - Keep batter texture and resting notes concise when expanding method content.
 - Keep mix-ins and topping notes practical, clearly labeled, and tied to the
   allergen event-serving guidance.
 - Keep `.github/workflows/check.yml` aligned with the local content baseline.
 - See `docs/plans/2026-06-10-hosted-content-checks.md` for the hosted content
   verification baseline.
+- See `docs/plans/2026-06-13-first-pancake-calibration.md` for the test-pancake
+  decision sequence.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 

--- a/VISION.md
+++ b/VISION.md
@@ -38,6 +38,8 @@ Current baseline:
   adjustments, and avoiding overmixing after the batter rests.
 - Griddle heat and doneness notes cover preheating, browning, flipping, and
   avoiding pressed pancakes.
+- First-pancake calibration separates heat corrections from measured flour or
+  milk adjustments before the main batch.
 - Troubleshooting notes cover common batch problems without adding app
   scaffolding.
 - Mix-ins and toppings notes describe when to fold, sprinkle, dry, organize,
@@ -66,6 +68,7 @@ Next priorities:
 - Keep portioning guidance practical and tied to the basic ratio
 - Keep batch scaling quantities aligned with the basic ratio and stated yield
 - Keep batter texture notes practical and tied to the basic method
+- Keep first-pancake calibration ordered and limited to one variable per test
 - Keep mix-ins and topping guidance practical and tied to event-serving labels
 
 Contribution rules:

--- a/docs/plans/2026-06-13-first-pancake-calibration.md
+++ b/docs/plans/2026-06-13-first-pancake-calibration.md
@@ -1,0 +1,71 @@
+---
+title: First Pancake Calibration
+type: content
+status: in_progress
+date: 2026-06-13
+---
+
+# First Pancake Calibration
+
+## Summary
+
+Add a short decision sequence that uses one measured test pancake to calibrate
+griddle heat and batter consistency before the rest of a batch is cooked.
+
+## Priority
+
+1. Turn the existing first-pancake advice into an actionable sequence.
+2. Keep heat corrections separate from batter-consistency corrections.
+3. Preserve the content-only, no-scaffold repository boundary.
+
+## Requirements
+
+- R1. The guide must use the existing 1/4 cup medium-pancake portion.
+- R2. It must tell the cook to evaluate browning before changing batter.
+- R3. It must map premature browning to lower heat and pale cooking to higher
+  heat.
+- R4. It must map excessive spread to a tablespoon of flour and a persistent
+  mound to a tablespoon of milk, with a short wait before reassessment.
+- R5. It must require a second test pancake after any adjustment instead of
+  changing multiple variables during the main batch.
+- R6. The static gate must preserve the heading, correction cues, ordering, and
+  completed verification evidence.
+
+## Non-Goals
+
+- Changing the base recipe, yield, batch scaling, or portion sizes.
+- Adding time or temperature claims beyond the existing guidance.
+- Adding application, dependency, publishing, or generated-site scaffolding.
+- Replacing the broader troubleshooting section.
+
+## Implementation Units
+
+### 1. Calibration Content
+
+Files: `pancakes.md`
+
+- Add a concise first-pancake decision sequence after the griddle guidance.
+- Keep each correction observable and limited to one variable at a time.
+
+### 2. Baseline Contract
+
+Files: `scripts/check-baseline.sh`
+
+- Require the new heading and exact adjustment cues.
+- Verify that browning evaluation precedes consistency correction and that a
+  second test follows any adjustment.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `VISION.md`, `CHANGES.md`
+
+- Record the new practical content and completed validation.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build`.
+- Remove the heat correction, remove the consistency correction, and reorder
+  the second-test instruction; the static gate must reject each mutation.
+- Run shell syntax, `git diff --check`, and intended-file secret scans.
+- Take one bounded exact-head pull-request and CodeQL snapshot after push; do
+  not poll.

--- a/docs/plans/2026-06-13-first-pancake-calibration.md
+++ b/docs/plans/2026-06-13-first-pancake-calibration.md
@@ -1,7 +1,7 @@
 ---
 title: First Pancake Calibration
 type: content
-status: in_progress
+status: completed
 date: 2026-06-13
 ---
 
@@ -69,3 +69,29 @@ Files: `README.md`, `VISION.md`, `CHANGES.md`
 - Run shell syntax, `git diff --check`, and intended-file secret scans.
 - Take one bounded exact-head pull-request and CodeQL snapshot after push; do
   not poll.
+
+## Work Completed
+
+- Added a seven-step first-pancake calibration sequence after the griddle heat
+  guidance.
+- Kept heat diagnosis ahead of measured flour or milk corrections and required
+  a second test before the main batch.
+- Extended the content baseline with wrap-stable cue checks, section-scoped
+  ordering validation, documentation contracts, and completed-plan evidence.
+- Updated README, VISION, and change history for the new method guidance.
+
+## Verification Completed
+
+- `make check`, `make lint`, `make test`, and `make build` passed against the
+  final implementation.
+- `sh -n scripts/check-baseline.sh`, `git diff --check`, the explicit
+  no-scaffold check, and the intended-file secret scan passed.
+- The heat correction mutation failed with `pancakes.md must keep the ordered
+  first-pancake calibration sequence.`
+- The consistency correction mutation failed with `First-pancake calibration
+  must preserve its fail-clear decision order.`
+- The second-test ordering mutation failed with `First-pancake calibration must
+  preserve its fail-clear decision order.`
+- The hosted pull-request check is not available before push; one bounded
+  exact-head snapshot will be recorded in the engineering tracker without
+  polling.

--- a/pancakes.md
+++ b/pancakes.md
@@ -94,6 +94,23 @@ yield can vary slightly after consistency adjustments or a different scoop.
 - After flipping, avoid pressing pancakes with the spatula; gentle contact keeps
   the interior lighter.
 
+## First Pancake Calibration
+
+- Pour one 1/4 cup test pancake and keep the remaining batter untouched while
+  it cooks.
+- Judge browning before changing the batter so heat and consistency are not
+  adjusted at the same time.
+- If the underside browns before bubbles open across the top, lower the heat
+  before the next test.
+- If the pancake remains pale after bubbles open and the edges set, raise heat
+  slightly before the next test.
+- Once the heat is corrected, fold in flour 1 tablespoon at a time if the test
+  pancake spreads too thin, then wait 1 minute before reassessing.
+- If the test pancake stays mounded instead of settling, stir in milk 1
+  tablespoon at a time, then wait 1 minute before reassessing.
+- After any adjustment, cook a second test pancake before starting the main
+  batch, and change only one variable between tests.
+
 ## Troubleshooting Pancakes
 
 - Flat pancakes usually need fresher leavening, a shorter wait after mixing, or

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -15,6 +15,7 @@ MIX_INS_PLAN="$ROOT_DIR/docs/plans/2026-06-09-pancake-mix-ins-toppings.md"
 RAW_BATTER_PLAN="$ROOT_DIR/docs/plans/2026-06-10-raw-batter-safety.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-content-checks.md"
 BATCH_SCALING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pancake-batch-scaling-table.md"
+CALIBRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-first-pancake-calibration.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -45,6 +46,7 @@ for path in \
   "docs/plans/2026-06-09-pancake-troubleshooting-section.md" \
   "docs/plans/2026-06-10-raw-batter-safety.md" \
   "docs/plans/2026-06-12-pancake-batch-scaling-table.md" \
+  "docs/plans/2026-06-13-first-pancake-calibration.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
@@ -214,6 +216,7 @@ for heading in \
   "## Types of Pancakes" \
   "## Pancake Tips" \
   "## Griddle Heat and Doneness" \
+  "## First Pancake Calibration" \
   "## Troubleshooting Pancakes" \
   "## Mix-Ins and Toppings" \
   "## Pancake-Related Events and Traditions" \
@@ -359,6 +362,46 @@ if ! grep -Fq "350 to 375 degrees F" "$ROOT_DIR/pancakes.md" ||
   exit 1
 fi
 
+if ! grep -Fq "Pour one 1/4 cup test pancake" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "Judge browning before changing the batter" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "underside browns before bubbles open" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "lower the heat" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "remains pale after bubbles open" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "raise heat" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "flour 1 tablespoon at a time" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "milk 1" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "tablespoon at a time" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "cook a second test pancake" "$ROOT_DIR/pancakes.md" ||
+  ! grep -Fq "change only one variable between tests" "$ROOT_DIR/pancakes.md"; then
+  printf '%s\n' "pancakes.md must keep the ordered first-pancake calibration sequence." >&2
+  exit 1
+fi
+
+python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+section = content.split("## First Pancake Calibration\n", 1)[-1].split(
+    "## Troubleshooting Pancakes", 1
+)[0]
+contract = (
+    "Pour one 1/4 cup test pancake",
+    "Judge browning before changing the batter",
+    "underside browns before bubbles open",
+    "remains pale after bubbles open",
+    "Once the heat is corrected",
+    "flour 1 tablespoon at a time",
+    "test pancake stays mounded",
+    "milk 1\n  tablespoon at a time",
+    "After any adjustment, cook a second test pancake",
+    "change only one variable between tests",
+)
+positions = [section.find(fragment) for fragment in contract]
+if -1 in positions or positions != sorted(positions) or len(set(positions)) != len(positions):
+    raise SystemExit("First-pancake calibration must preserve its fail-clear decision order.")
+PY
+
 if ! grep -Fq "<title id=\"title\">fantastic-pancake project overview</title>" "$ROOT_DIR/docs/readme-overview.svg"; then
   printf '%s\n' "README overview image must describe this repository." >&2
   exit 1
@@ -459,6 +502,27 @@ if (
 ):
     raise SystemExit(
         "The batch scaling plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$CALIBRATION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+required = (
+    "heat correction mutation failed",
+    "consistency correction mutation failed",
+    "second-test ordering mutation failed",
+    "hosted pull-request check",
+)
+
+if statuses != ["status: completed"] or any(item not in plan for item in required):
+    raise SystemExit(
+        "The first-pancake calibration plan must record completed status and actual verification."
     )
 PY
 


### PR DESCRIPTION
## Summary

The first pancake now provides an ordered way to calibrate a batch instead of being a vague test. The guide separates heat corrections from tablespoon-by-tablespoon flour or milk changes, then requires a second test before the main batch so cooks do not change multiple variables at once.

## Baseline

The content baseline preserves the decision order and rejects missing heat guidance, missing consistency guidance, or a prematurely moved second-test instruction.

## Improvements

- Separates heat corrections from flour-or-milk consistency adjustments.
- Makes tablespoon-by-tablespoon adjustments explicit.
- Requires a second test before committing the main batch.
- Prevents changing multiple variables at once.

## Validation

- `make check`
- `make lint`
- `make test`
- `make build`
- `sh -n scripts/check-baseline.sh`
- Explicit no-scaffold check
- `git diff --check`
- Scoped intended-file secret scan
- Three hostile mutation checks

## Risk

This is guidance and baseline-validation work rather than an executable application change. The main risk is instructional drift that weakens the ordered calibration sequence; the baseline and hostile mutation checks cover that contract.

## Follow-Ups

No additional follow-up is required for this scoped first-pancake calibration change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
