### PR TITLE
Add source-backed pancake substitution guidance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Added source-backed ingredient substitution guidance with test-batch,
+  ingredient-function, label-review, and cross-contact boundaries.
+- Extended the content baseline to preserve the substitution safety contract
+  and completed verification evidence.
 - Added a first-pancake calibration sequence that separates heat corrections
   from tablespoon-by-tablespoon batter adjustments.
 - Extended the content baseline to preserve the calibration order and completed

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ FoodSafety.gov source, and enforces a no-scaffold contract so app manifests,
 dependency lockfiles, source directories, and generated dependency directories
 do not appear without a new plan. Event serving notes must keep source-backed
 allergen guidance, separate utensil language, and avoid unsupported
-allergen-free claims. Mix-ins and toppings notes must keep practical texture,
+allergen-free claims. Ingredient substitutions must preserve function and
+test-batch cautions, current label review, cross-contact controls, and official
+or reviewed sources. Mix-ins and toppings notes must keep practical texture,
 fruit, and labeling guidance. Batch notes must keep specific holding, storage,
 and reheating thresholds.
 
@@ -104,6 +106,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
 - Keep griddle heat and doneness notes practical when expanding method content.
 - Keep first-pancake calibration tied to the 1/4 cup portion and one-variable
   adjustments.
+- Keep substitution guidance tied to the about-8-pancake test batch and
+  separate recipe adaptation from allergen-safety claims.
 - Keep batter texture and resting notes concise when expanding method content.
 - Keep mix-ins and topping notes practical, clearly labeled, and tied to the
   allergen event-serving guidance.
@@ -112,6 +116,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   verification baseline.
 - See `docs/plans/2026-06-13-first-pancake-calibration.md` for the test-pancake
   decision sequence.
+- See `docs/plans/2026-06-13-pancake-substitution-guidance.md` for substitution
+  and allergy-safety boundaries.
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 

--- a/VISION.md
+++ b/VISION.md
@@ -40,6 +40,8 @@ Current baseline:
   avoiding pressed pancakes.
 - First-pancake calibration separates heat corrections from measured flour or
   milk adjustments before the main batch.
+- Ingredient substitution notes distinguish milk, egg, flour, and fat behavior
+  from allergen safety and require an about-8-pancake test batch before scaling.
 - Troubleshooting notes cover common batch problems without adding app
   scaffolding.
 - Mix-ins and toppings notes describe when to fold, sprinkle, dry, organize,
@@ -69,6 +71,8 @@ Next priorities:
 - Keep batch scaling quantities aligned with the basic ratio and stated yield
 - Keep batter texture notes practical and tied to the basic method
 - Keep first-pancake calibration ordered and limited to one variable per test
+- Keep substitution guidance source-backed and separate recipe adaptation from
+  allergen-free claims
 - Keep mix-ins and topping guidance practical and tied to event-serving labels
 
 Contribution rules:

--- a/docs/plans/2026-06-13-pancake-substitution-guidance.md
+++ b/docs/plans/2026-06-13-pancake-substitution-guidance.md
@@ -1,7 +1,7 @@
 ---
 title: Pancake Substitution Guidance
 type: content
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -99,8 +99,26 @@ Files: `README.md`, `VISION.md`, `CHANGES.md`
 
 ## Work Completed
 
-Pending implementation.
+- Added function-aware milk, egg, flour, and fat substitution guidance after
+  the base ratio.
+- Required an about-8-pancake test before scaling and kept consistency changes
+  tied to the existing batter rest.
+- Added reviewed University of Minnesota Extension egg guidance and current FDA
+  label and cross-contact guidance.
+- Extended the content baseline with wrap-stable section checks, documentation
+  contracts, and completed-plan evidence.
+- Updated README, VISION, and change history for the new content boundary.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- `make check`, `make lint`, `make test`, and `make build` passed against the
+  final implementation.
+- The egg-function mutation failed with `pancakes.md must keep source-backed,
+  function-aware substitution guidance.`
+- The flour-boundary mutation failed with the same substitution-contract error.
+- The allergen-boundary mutation failed with the same substitution-contract
+  error.
+- The source-link mutation failed with the same substitution-contract error.
+- The hosted pull-request check is not available before the implementation
+  push; bounded exact-head evidence will be recorded in the engineering tracker
+  without a watch loop.

--- a/docs/plans/2026-06-13-pancake-substitution-guidance.md
+++ b/docs/plans/2026-06-13-pancake-substitution-guidance.md
@@ -1,0 +1,106 @@
+---
+title: Pancake Substitution Guidance
+type: content
+status: planned
+date: 2026-06-13
+---
+
+# Pancake Substitution Guidance
+
+## Summary
+
+Add concise substitution guidance for the base pancake ratio that explains
+which ingredient function may change, requires a small test batch, and keeps
+recipe adaptation separate from allergen-safety claims.
+
+## Priority
+
+1. Help cooks adapt the existing recipe without promising identical results.
+2. Keep egg, milk, flour, and fat substitutions tied to observable batter and
+   pancake behavior.
+3. Preserve official label and cross-contact guidance for allergy-sensitive
+   preparation.
+4. Preserve the content-only, no-scaffold repository boundary.
+
+## Requirements
+
+- R1. The guide must state that substitutions can change flavor, color,
+  texture, or volume and recommend testing the 8-pancake ratio before scaling.
+- R2. Milk guidance must use an unsweetened replacement and direct cooks to
+  reassess batter thickness after the existing rest.
+- R3. Egg guidance must explain that eggs contribute moisture, binding, and
+  lift and that no single replacement reproduces every function.
+- R4. Flour guidance must avoid presenting an arbitrary single gluten-free
+  flour as a cup-for-cup replacement and must require a blend intended for
+  one-to-one baking use.
+- R5. Fat guidance must keep the existing neutral-oil option and identify
+  butter-related flavor or browning as a possible difference.
+- R6. Allergy guidance must require current label review and cross-contact
+  controls and must prohibit treating a substitution alone as proof that a
+  batch is allergen-free.
+- R7. The content must cite current FDA food-allergy guidance and reviewed
+  university extension guidance for egg replacements.
+- R8. The static gate must preserve the heading, functional cautions, source
+  links, test-batch boundary, allergy boundary, and completed verification
+  evidence.
+
+## Non-Goals
+
+- Guaranteeing identical flavor, browning, texture, rise, or yield after a
+  substitution.
+- Providing individualized medical, allergy-treatment, or dietary advice.
+- Replacing tested recipes for highly constrained diets.
+- Changing the base recipe, batch scaling table, or event-serving thresholds.
+- Adding application, dependency, publishing, or generated-site scaffolding.
+
+## Implementation Units
+
+### 1. Substitution Content
+
+Files: `pancakes.md`
+
+- Add a concise section after the base ratio and before batch scaling.
+- Cover milk, egg, flour, and fat without presenting the options as equivalent.
+- Require a small test batch before group-scale preparation.
+
+### 2. Source And Safety Boundary
+
+Files: `pancakes.md`
+
+- Cite FDA food-allergy label and cross-contact guidance.
+- Cite University of Minnesota Extension guidance on the different functions
+  eggs serve and the limits of a universal replacement.
+- Connect the new section to the existing allergen and event-serving notes.
+
+### 3. Baseline Contract
+
+Files: `scripts/check-baseline.sh`
+
+- Require the new plan and section heading.
+- Preserve the substitution cautions, source links, test-batch boundary, and
+  allergen-safety boundary with wrap-stable checks.
+
+### 4. Repository Guidance
+
+Files: `README.md`, `VISION.md`, `CHANGES.md`
+
+- Record the new practical content and completed validation.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build`.
+- Remove the egg-function caution, replace the flour boundary with a generic
+  cup-for-cup claim, remove the allergen boundary, and remove a source link;
+  the static gate must reject each mutation.
+- Run shell syntax, `git diff --check`, explicit no-scaffold verification, and
+  intended-file secret scans.
+- Take bounded exact-head pull-request, workflow, and code-scanning snapshots
+  after push; do not start a watch loop.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/pancakes.md
+++ b/pancakes.md
@@ -21,6 +21,32 @@ for breakfast, brunch, dessert, or community events.
 - Scale dry and wet ingredients together when cooking for a group, then adjust
   thickness after the batter rests.
 
+## Ingredient Substitutions
+
+Substitutions can change flavor, color, texture, or volume. Test the
+about-8-pancake ratio before scaling an adapted batch for a group.
+
+- For milk, start with the same amount of an unsweetened replacement, then
+  reassess the rested batter before adding more liquid. Different products can
+  change thickness, flavor, and browning.
+- Eggs add moisture, binding, and lift, so no single egg replacement reproduces
+  every function. For this one-egg ratio, follow a baking egg replacer's label
+  or a reviewed substitution amount; fruit purees can add flavor and moisture
+  while producing a different rise or texture.
+- For a wheat-flour substitution, use a gluten-free blend labeled as a
+  one-to-one replacement for all-purpose flour and follow its directions. Do
+  not assume a single alternative flour will work cup for cup.
+- The ratio already allows 2 tablespoons of neutral oil instead of melted
+  butter; expect butter-related flavor or browning to differ when using oil.
+- A substitution does not prove a batch is allergen-free. Check current
+  ingredient and advisory labels every time, and control cross-contact from
+  prep surfaces, utensils, and equipment before serving someone with an
+  allergy.
+- University of Minnesota Extension explains egg functions and replacement
+  tradeoffs: https://extension.umn.edu/family-news/egg-substitutions-baking
+- FDA food-allergy guidance covers current labels and cross-contact:
+  https://www.fda.gov/food/food-labeling-nutrition/food-allergies
+
 ## Batch Scaling Table
 
 The amounts below assume the 1/4 cup portion used for medium pancakes. Final

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -16,6 +16,7 @@ RAW_BATTER_PLAN="$ROOT_DIR/docs/plans/2026-06-10-raw-batter-safety.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-content-checks.md"
 BATCH_SCALING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pancake-batch-scaling-table.md"
 CALIBRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-first-pancake-calibration.md"
+SUBSTITUTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-pancake-substitution-guidance.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -47,6 +48,7 @@ for path in \
   "docs/plans/2026-06-10-raw-batter-safety.md" \
   "docs/plans/2026-06-12-pancake-batch-scaling-table.md" \
   "docs/plans/2026-06-13-first-pancake-calibration.md" \
+  "docs/plans/2026-06-13-pancake-substitution-guidance.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
@@ -85,7 +87,8 @@ if ! grep -Fq "make check" "$ROOT_DIR/README.md" ||
   ! grep -Fq "content-only" "$ROOT_DIR/README.md" ||
   ! grep -Fq "no-scaffold" "$ROOT_DIR/README.md" ||
   ! grep -Fq "GitHub Actions" "$ROOT_DIR/README.md" ||
-  ! grep -Fq "Mix-ins and toppings" "$ROOT_DIR/README.md"; then
+  ! grep -Fq "Mix-ins and toppings" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Ingredient substitutions" "$ROOT_DIR/README.md"; then
   printf '%s\n' "README must document the content-only baseline and verification command." >&2
   exit 1
 fi
@@ -95,7 +98,8 @@ if ! grep -Fq "scripts/check-baseline.sh" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "pancakes.md" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "dependency manifests" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "GitHub Actions" "$ROOT_DIR/VISION.md" ||
-  ! grep -Fq "Mix-ins and toppings" "$ROOT_DIR/VISION.md"; then
+  ! grep -Fq "Mix-ins and toppings" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Ingredient substitution notes" "$ROOT_DIR/VISION.md"; then
   printf '%s\n' "VISION must describe the current content baseline." >&2
   exit 1
 fi
@@ -210,6 +214,7 @@ for heading in \
   "# Pancakes" \
   "## Basic Pancake Method" \
   "## Basic Pancake Ratio" \
+  "## Ingredient Substitutions" \
   "## Batch Scaling Table" \
   "## Portioning and Batch Size" \
   "## Batter Consistency and Resting" \
@@ -282,6 +287,39 @@ if ! grep -Fq "1 cup flour" "$ROOT_DIR/pancakes.md" ||
   printf '%s\n' "pancakes.md must keep a practical basic pancake ratio." >&2
   exit 1
 fi
+
+python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+content = Path(sys.argv[1]).read_text()
+section = content.split("## Ingredient Substitutions\n", 1)[-1].split(
+    "## Batch Scaling Table", 1
+)[0]
+normalized = re.sub(r"\s+", " ", section).strip()
+required = (
+    "Substitutions can change flavor, color, texture, or volume.",
+    "Test the about-8-pancake ratio before scaling",
+    "same amount of an unsweetened replacement",
+    "reassess the rested batter",
+    "Eggs add moisture, binding, and lift",
+    "no single egg replacement reproduces every function",
+    "one-to-one replacement for all-purpose flour",
+    "Do not assume a single alternative flour will work cup for cup.",
+    "2 tablespoons of neutral oil instead of melted butter",
+    "A substitution does not prove a batch is allergen-free.",
+    "Check current ingredient and advisory labels every time",
+    "control cross-contact from prep surfaces, utensils, and equipment",
+    "https://extension.umn.edu/family-news/egg-substitutions-baking",
+    "https://www.fda.gov/food/food-labeling-nutrition/food-allergies",
+)
+
+if any(fragment not in normalized for fragment in required):
+    raise SystemExit(
+        "pancakes.md must keep source-backed, function-aware substitution guidance."
+    )
+PY
 
 if ! grep -Fq "1/4 cup scoop" "$ROOT_DIR/pancakes.md" ||
   ! grep -Fq "2 tablespoons of batter" "$ROOT_DIR/pancakes.md" ||
@@ -523,6 +561,28 @@ required = (
 if statuses != ["status: completed"] or any(item not in plan for item in required):
     raise SystemExit(
         "The first-pancake calibration plan must record completed status and actual verification."
+    )
+PY
+
+python3 - "$SUBSTITUTION_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+required = (
+    "egg-function mutation failed",
+    "flour-boundary mutation failed",
+    "allergen-boundary mutation failed",
+    "source-link mutation failed",
+    "hosted pull-request check",
+)
+
+if statuses != ["status: completed"] or any(item not in plan for item in required):
+    raise SystemExit(
+        "The substitution plan must record completed status and actual verification."
     )
 PY
 


### PR DESCRIPTION
## Summary

Add source-backed pancake substitution guidance while keeping recipe adaptation separate from allergen-safety claims.

## Baseline

The repository is intentionally content-only and enforces a no-scaffold contract. The existing base ratio names milk, egg, wheat flour, and butter or oil but did not explain substitution tradeoffs or require a small adapted test batch. This PR is stacked on #6 so its diff contains only the substitution-guidance plan and implementation.

## Improvements

- add milk, egg, flour, and fat guidance tied to observable recipe behavior
- require an about-8-pancake test before scaling an adapted batch
- require current label review and cross-contact controls instead of treating a substitution as proof of allergen safety
- cite current FDA food-allergy guidance and reviewed University of Minnesota Extension egg guidance
- extend the content baseline with wrap-stable substitution, source, and completed-plan contracts

## Validation

- `make check`
- `make lint`
- `make test`
- `make build`
- `sh -n scripts/check-baseline.sh`
- `git diff --check`
- hostile mutations for egg function, flour boundary, allergen boundary, and source link all rejected
- explicit no-scaffold, intended-file secret, and artifact checks passed

## Risk

The change is limited to Markdown and the existing POSIX shell content gate. Ingredient replacements can still produce different results, and readers with allergies must verify every current label and control cross-contact rather than relying on this general guidance as individualized medical advice.

## Follow-Ups

Keep the PR stacked on #6 until the owner chooses an integration order. Revalidate the cited public-health sources when expanding substitution or allergen guidance. Do not merge or close this PR without explicit owner authorization.
