### PR TITLE
test: enforce source provenance boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Added structural source provenance checks for HTTPS, userinfo, ports,
+  approved hosts, and continued representation of every reviewed source host.
 - Added source-backed ingredient substitution guidance with test-batch,
   ingredient-function, label-review, and cross-contact boundaries.
 - Extended the content baseline to preserve the substitution safety contract

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ test-batch cautions, current label review, cross-contact controls, and official
 or reviewed sources. Mix-ins and toppings notes must keep practical texture,
 fruit, and labeling guidance. Batch notes must keep specific holding, storage,
 and reheating thresholds.
+Guide citations are limited to credential-free HTTPS URLs on approved official
+government and university-extension hosts; this offline check does not claim
+that remote pages are currently reachable.
 
 The `make lint`, `make test`, and `make build` aliases run the same content
 baseline while this repository has no narrower installed gates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,9 @@ Helpful reports include:
 - This repository appears to be a public sample, documentation, or utility project. The active security scope is the code and documentation on the default branch.
 - The repository scan did not identify production authentication, payment, or secret-management code. Treat the project as public sample code unless future changes add sensitive surfaces.
 - No primary dependency manifest was detected in the repository root. If dependencies are added later, include a manifest and prefer reproducible installation instructions.
+- Safety and substitution citations in `pancakes.md` must use credential-free
+  HTTPS URLs from the reviewed source hosts; adding another host requires an
+  explicit source-review change.
 - Food allergy and event-serving guidance can affect reader safety. Keep allergen claims source-backed and avoid promising allergen-free food without controlled ingredients, utensils, and prep surfaces.
 - Mix-ins and topping guidance should preserve clear allergen labels and separate serving-utensil language for shared pancake bars.
 - GitHub Actions runs the content and no-scaffold baseline with read-only

--- a/VISION.md
+++ b/VISION.md
@@ -48,6 +48,8 @@ Current baseline:
   and label additions without changing the content-only scope.
 - Food-safety notes cite FoodSafety.gov before making storage or serving
   recommendations.
+- The offline baseline structurally validates source URLs for HTTPS, absent
+  credentials and ports, exact reviewed hosts, and continued host coverage.
 - Batch storage and reheating guidance includes concrete holding, cooling,
   reheating, and leftover-use thresholds.
 - README and VISION document the no-scaffold boundary until there is a concrete

--- a/docs/plans/2026-06-13-source-provenance-boundary.md
+++ b/docs/plans/2026-06-13-source-provenance-boundary.md
@@ -1,0 +1,60 @@
+# Source Provenance Boundary
+
+status: planned
+
+## Context
+
+The guide pins several individual safety and substitution links, but the
+baseline does not structurally reject newly added cleartext, credential-bearing,
+or unreviewed external sources. Source provenance should fail closed as the
+guide evolves.
+
+## Requirements
+
+- R1. Parse every absolute URL in `pancakes.md` with a structured URL parser.
+- R2. Require HTTPS, a hostname, no username or password, and no explicit port.
+- R3. Permit only the reviewed source hosts already used by the guide:
+  `www.cdc.gov`, `www.fda.gov`, `www.foodsafety.gov`, and
+  `extension.umn.edu`.
+- R4. Require every reviewed host to remain represented so source breadth
+  cannot silently collapse while individual phrase checks still pass.
+- R5. Preserve all existing recipe, substitution, food-safety, and citation
+  content.
+- R6. Document the source boundary and add mutation-sensitive completed-plan
+  evidence.
+
+## Implementation Units
+
+### U1. Structural URL Contract
+
+**Files:** `scripts/check-baseline.sh`
+
+Use Python's URL parser to extract absolute links from the canonical guide and
+validate scheme, authority, userinfo, port, and exact host membership. Keep the
+existing link-specific contracts as independent content evidence.
+
+### U2. Guidance And Evidence
+
+**Files:** `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`,
+`docs/plans/2026-06-13-source-provenance-boundary.md`
+
+Record the approved source classes without implying that offline checks prove
+remote availability or ongoing editorial accuracy.
+
+## Verification Plan
+
+- Run `make lint`, `make test`, `make build`, and `make check`.
+- Reject isolated HTTP, userinfo, explicit-port, unapproved-host, missing-host,
+  malformed-authority, docs, plan-status, and evidence mutations.
+- Run shell syntax, `git diff --check`, exact-path review, generated-artifact
+  inspection, and added-line secret scanning.
+- Use no network fetch as proof of source availability; hosted checks remain
+  the authoritative execution evidence after push.
+
+## Non-Goals
+
+- Fetching remote pages, adding a link-check dependency, or claiming that a URL
+  is currently reachable.
+- Changing recipe quantities, culinary claims, safety advice, or cited pages.
+- Expanding the allowlist beyond the current official government and university
+  extension sources.

--- a/docs/plans/2026-06-13-source-provenance-boundary.md
+++ b/docs/plans/2026-06-13-source-provenance-boundary.md
@@ -1,6 +1,6 @@
 # Source Provenance Boundary
 
-status: planned
+status: completed
 
 ## Context
 
@@ -58,3 +58,24 @@ remote availability or ongoing editorial accuracy.
 - Changing recipe quantities, culinary claims, safety advice, or cited pages.
 - Expanding the allowlist beyond the current official government and university
   extension sources.
+
+## Work Completed
+
+- Added structured parsing for every absolute URL in `pancakes.md`.
+- Required HTTPS, a hostname, absent userinfo and explicit ports, exact approved
+  hosts, and continued representation of every reviewed host.
+- Kept all existing exact citation and content checks as independent evidence.
+- Documented the offline provenance boundary without claiming remote reachability.
+
+## Verification Completed
+
+- The all four Make gates passed the content baseline, along with shell syntax
+  and `git diff --check`.
+- Eleven isolated hostile mutations were rejected: HTTP, alternate scheme,
+  username, explicit port, empty port delimiter, unapproved host, missing
+  reviewed host, malformed authority, missing docs, stale plan status, and
+  missing verification evidence.
+- Exact intended-path review, generated-artifact inspection, and added-line
+  secret-pattern scanning passed.
+- No network fetch, remote-page availability claim, credential, or external
+  service was used during verification.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -17,6 +17,7 @@ CI_PLAN="$ROOT_DIR/docs/plans/2026-06-10-hosted-content-checks.md"
 BATCH_SCALING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pancake-batch-scaling-table.md"
 CALIBRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-first-pancake-calibration.md"
 SUBSTITUTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-pancake-substitution-guidance.md"
+SOURCE_PROVENANCE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-source-provenance-boundary.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -49,6 +50,7 @@ for path in \
   "docs/plans/2026-06-12-pancake-batch-scaling-table.md" \
   "docs/plans/2026-06-13-first-pancake-calibration.md" \
   "docs/plans/2026-06-13-pancake-substitution-guidance.md" \
+  "docs/plans/2026-06-13-source-provenance-boundary.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
@@ -240,6 +242,50 @@ if [ "$bullet_count" -lt 20 ]; then
   printf '%s\n' "pancakes.md must keep enough specific content bullets." >&2
   exit 1
 fi
+
+python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+content = Path(sys.argv[1]).read_text(encoding="utf-8")
+urls = re.findall(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s<>)\]]+", content)
+approved_hosts = {
+    "extension.umn.edu",
+    "www.cdc.gov",
+    "www.fda.gov",
+    "www.foodsafety.gov",
+}
+
+if not urls:
+    raise SystemExit("pancakes.md must retain reviewed external sources.")
+
+observed_hosts = set()
+for value in urls:
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as error:
+        raise SystemExit(f"Invalid source URL authority: {value}") from error
+
+    host = parsed.hostname
+    if (
+        parsed.scheme != "https"
+        or not host
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+        or parsed.netloc.lower() != host
+        or host not in approved_hosts
+    ):
+        raise SystemExit(f"Unapproved source URL: {value}")
+    observed_hosts.add(host)
+
+if observed_hosts != approved_hosts:
+    missing = ", ".join(sorted(approved_hosts - observed_hosts))
+    raise SystemExit(f"pancakes.md must retain every reviewed source host: {missing}")
+PY
 
 python3 - "$ROOT_DIR/pancakes.md" <<'PY'
 import sys
@@ -585,5 +631,21 @@ if statuses != ["status: completed"] or any(item not in plan for item in require
         "The substitution plan must record completed status and actual verification."
     )
 PY
+
+if ! grep -Fq "status: completed" "$SOURCE_PROVENANCE_PLAN" ||
+  ! grep -Fq "hostile mutations were rejected" "$SOURCE_PROVENANCE_PLAN" ||
+  ! grep -Fq "No network fetch" "$SOURCE_PROVENANCE_PLAN" ||
+  ! grep -Fq "all four Make gates" "$SOURCE_PROVENANCE_PLAN"; then
+  printf '%s\n' "Source provenance plan must record completed local verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "credential-free HTTPS URLs on approved official" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "HTTPS URLs from the reviewed source hosts" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "structurally validates source URLs" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Added structural source provenance checks" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Project guidance must preserve the source provenance boundary." >&2
+  exit 1
+fi
 
 printf '%s\n' "fantastic-pancake content baseline checks passed."


### PR DESCRIPTION
## Summary

New guide citations can no longer silently introduce cleartext links, embedded credentials, explicit ports, or unreviewed hosts. The offline baseline now parses every absolute URL in `pancakes.md` and keeps all four reviewed government and university-extension source families represented.

## Validation

- `make lint`, `make test`, `make build`, and `make check`
- eleven isolated hostile URL, documentation, and plan mutations rejected
- shell syntax and `git diff --check`
- exact-path, generated-artifact, and added-line secret scans passed
- review found and fixed an explicit empty-port delimiter bypass
- no network fetch or remote availability claim used as evidence
- exact head `31b343bc3cde1ec4df35ba6496db4552fae7b991`
- push run `27470424438`, job `81200230367`: SUCCESS
- pull-request run `27470427349`, job `81200237315`: SUCCESS
- zero open code-scanning alerts on the head branch

## Stack

Base: `lfg/fantastic-pancake-substitution-guidance-20260613` (PR #7). Merge in base order; do not merge this PR independently.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is an offline Markdown validation contract. After merge, the repository owner should confirm the canonical `make check` workflow remains green on citation edits; any `Unapproved source URL`, `Invalid source URL authority`, or missing reviewed-host failure is the rollback or correction trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
