### PR TITLE
Make content checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made content verification independent of the caller's working directory by
+  resolving the baseline checker from the loaded Makefile.
 - Added structural source provenance checks for HTTPS, userinfo, ports,
   approved hosts, and continued representation of every reviewed source host.
 - Added source-backed ingredient substitution guidance with test-batch,

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 check:
-	./scripts/check-baseline.sh
+	@"$(ROOT)/scripts/check-baseline.sh"
 
 lint: check
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Run the content baseline:
 make check
 ```
 
+Use the absolute Makefile path to run the same gate from another working
+directory. Verification resolves the checker relative to the loaded Makefile
+rather than the caller's directory.
+
 The baseline verifies that the repository remains content-only, README/VISION
 stay linked to `pancakes.md`, the overview image targets this repo, and the
 pancake document keeps real sections instead of placeholder separators. It also

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,47 @@
+---
+title: Location-Independent Content Verification
+type: reliability
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+# Location-Independent Content Verification
+
+## Summary
+
+Resolve the content checker from the loaded Makefile so the full repository
+baseline works when Make is invoked outside the checkout.
+
+## Requirements
+
+- R1. Derive the repository root from `MAKEFILE_LIST`.
+- R2. Invoke `scripts/check-baseline.sh` through its repository-rooted path.
+- R3. Add a static contract that rejects caller-directory-relative checker
+  invocation.
+- R4. Preserve all recipe, food-safety, allergen, source-provenance, workflow,
+  and no-scaffold contracts.
+- R5. Record actual root and external-directory verification before completion.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` at repository
+  root.
+- Run the full gate from `/tmp` through the absolute Makefile path.
+- Reject isolated hostile root-derivation, checker-path, documentation, plan
+  status, and verification-evidence mutations.
+- Run shell syntax, `git diff --check`, exact-path review, secret scanning, and
+  generated-artifact inspection.
+
+## Non-Goals
+
+- Changing recipe content, safety guidance, citations, or publishing scope.
+- Adding dependencies, application scaffolding, or network validation.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -2,7 +2,7 @@
 title: Location-Independent Content Verification
 type: reliability
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -40,8 +40,19 @@ baseline works when Make is invoked outside the checkout.
 
 ## Work Completed
 
-Pending implementation.
+- Derived the repository root from the loaded Makefile and invoked the content
+  checker through that absolute path.
+- Extended the baseline with rooted-Makefile, completed-plan, external-run, and
+  synchronized guidance contracts.
+- Preserved all recipe, food-safety, allergen, citation, workflow, and
+  no-scaffold content unchanged.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- `make check`, `make lint`, `make test`, and `make build` passed at repository
+  root.
+- The full gate passed from /tmp through the absolute Makefile path.
+- Five isolated hostile root-derivation, checker-path, documentation, plan
+  status, and verification-evidence mutations were rejected.
+- Shell syntax, `git diff --check`, exact-path review, added-line secret
+  scanning, and generated-artifact inspection passed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -18,6 +18,7 @@ BATCH_SCALING_PLAN="$ROOT_DIR/docs/plans/2026-06-12-pancake-batch-scaling-table.
 CALIBRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-first-pancake-calibration.md"
 SUBSTITUTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-pancake-substitution-guidance.md"
 SOURCE_PROVENANCE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-source-provenance-boundary.md"
+LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -51,10 +52,25 @@ for path in \
   "docs/plans/2026-06-13-first-pancake-calibration.md" \
   "docs/plans/2026-06-13-pancake-substitution-guidance.md" \
   "docs/plans/2026-06-13-source-provenance-boundary.md" \
+  "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
 done
+
+if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
+  printf '%s\n' "Makefile verification must resolve the checker from the loaded Makefile." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "from /tmp" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "absolute Makefile path" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Made content verification independent" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Location-independent Make plan and guidance must record completed external verification." >&2
+  exit 1
+fi
 
 for path in \
   "Cargo.toml" \


### PR DESCRIPTION
## Summary

Make the content verification gate work when Make is invoked outside the
repository checkout.

## Baseline

`make -f <absolute Makefile> check` from `/tmp` exited 127 because the Makefile
resolved `./scripts/check-baseline.sh` against the caller's working directory.

## Improvements

- Derive the repository root from `MAKEFILE_LIST`.
- Invoke the baseline checker through its repository-rooted absolute path.
- Enforce the rooted recipe, completed plan evidence, and synchronized guidance
  with mutation-sensitive static contracts.
- Preserve recipe, safety, allergen, citation, workflow, and no-scaffold content.

## Validation

- `make check`, `make lint`, `make test`, and `make build`
- `make -f "$PWD/Makefile" -C /tmp check`
- `sh -n scripts/check-baseline.sh`
- Five isolated hostile mutations covering root derivation, checker path,
  documentation, plan status, and external-run evidence
- `git diff --check`, exact intended-path review, added-line secret scan, and
  generated-artifact scan

## Risk

Low. The change only affects how Make locates the existing checker. It does not
change pancake content, safety guidance, dependencies, workflows, or publishing
scope. This PR is stacked and depends on the source-provenance PR remaining
available and merging first.

## Follow-Ups

- Require terminal hosted checks on this exact head before merge.
- Merge only after the stacked base is available and with explicit owner
  authorization.
