### PR TITLE
Protect Make root from caller overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build check lint test
 
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 check:
 	@"$(ROOT)/scripts/check-baseline.sh"

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -2,7 +2,7 @@
 title: Make Root Override Protection
 type: reliability
 date: 2026-06-14
-status: in_progress
+status: completed
 execution: code
 ---
 
@@ -38,7 +38,17 @@ supplies a hostile `ROOT` command-line variable.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- `sh -n scripts/check-baseline.sh` and `dash -n scripts/check-baseline.sh`
+  passed.
+- All four Make gates passed: `make check`, `make lint`, `make test`, and
+  `make build`.
+- `make ROOT=/tmp check` passed and still executed the repository checker.
+- The full gate passed from `/tmp` through the absolute Makefile path, covering
+  the external working directory.
+- Overrideable-root, missing-plan-file, reopened-plan, and missing-verification
+  mutations were rejected.
+- `git diff --check`, intended-path review, artifact inspection, and the
+  changed-line secret scan passed.
 
 ## Follow-Ups
 

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,45 @@
+---
+title: Make Root Override Protection
+type: reliability
+date: 2026-06-14
+status: in_progress
+execution: code
+---
+
+# Make Root Override Protection
+
+## Summary
+
+Keep repository verification anchored to the loaded Makefile even when a caller
+supplies a hostile `ROOT` command-line variable.
+
+## Requirements
+
+- R1. Prevent command-line variables from overriding the repository-derived
+  Make root.
+- R2. Preserve repository-root and external-working-directory verification.
+- R3. Add a static contract that rejects an overrideable root assignment.
+- R4. Verify the full gate with a hostile `ROOT` value.
+- R5. Preserve all existing content, source, safety, workflow, and no-scaffold
+  contracts.
+
+## Verification Plan
+
+- Run POSIX shell syntax checks for `scripts/check-baseline.sh`.
+- Run `make check`, `make lint`, `make test`, and `make build` at repository
+  root.
+- Run the full gate from `/tmp` through the absolute Makefile path.
+- Run `make ROOT=/tmp check` and confirm the repository checker still runs.
+- Reject isolated mutations that restore an overrideable root, remove the
+  hostile-override verification record, reopen the plan, or omit the plan from
+  the required-file contract.
+- Run `git diff --check`, intended-path review, artifact inspection, and a
+  changed-line secret scan.
+
+## Verification Completed
+
+Pending implementation and validation.
+
+## Follow-Ups
+
+- Keep future Make targets anchored to the protected repository root.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -19,6 +19,7 @@ CALIBRATION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-first-pancake-calibration.md"
 SUBSTITUTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-pancake-substitution-guidance.md"
 SOURCE_PROVENANCE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-source-provenance-boundary.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
+MAKE_ROOT_PROTECTION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-make-root-override-protection.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -53,14 +54,15 @@ for path in \
   "docs/plans/2026-06-13-pancake-substitution-guidance.md" \
   "docs/plans/2026-06-13-source-provenance-boundary.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
+  "docs/plans/2026-06-14-make-root-override-protection.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
 done
 
-if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
+if ! grep -Fq 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
   ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
-  printf '%s\n' "Makefile verification must resolve the checker from the loaded Makefile." >&2
+  printf '%s\n' "Makefile verification must protect and resolve the checker from the loaded Makefile." >&2
   exit 1
 fi
 
@@ -69,6 +71,14 @@ if ! grep -Fq "status: completed" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
   ! grep -Fq "absolute Makefile path" "$ROOT_DIR/README.md" ||
   ! grep -Fq "Made content verification independent" "$ROOT_DIR/CHANGES.md"; then
   printf '%s\n' "Location-independent Make plan and guidance must record completed external verification." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$MAKE_ROOT_PROTECTION_PLAN" ||
+  ! grep -Fq 'make ROOT=/tmp check' "$MAKE_ROOT_PROTECTION_PLAN" ||
+  ! grep -Fq "four Make gates" "$MAKE_ROOT_PROTECTION_PLAN" ||
+  ! grep -Fq "external working directory" "$MAKE_ROOT_PROTECTION_PLAN"; then
+  printf '%s\n' "Make root protection plan must record completed hostile-override and external verification." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Keep the content baseline anchored to this repository when callers pass a hostile Make `ROOT` variable.

## Baseline

The location-independent Makefile derived `ROOT` from `MAKEFILE_LIST`, but a command-line assignment still took precedence. Before this change, `make ROOT=/tmp check` attempted to execute `/tmp/scripts/check-baseline.sh` and failed with exit 127.

## Improvements

- Protect the repository-derived root with GNU Make's `override` directive.
- Require the protected assignment in the baseline checker.
- Require a completed plan with hostile-override and external-directory verification evidence.

## Validation

- `sh -n scripts/check-baseline.sh`
- `dash -n scripts/check-baseline.sh`
- Direct baseline checker from the repository and `/tmp`
- `make check`, `make lint`, `make test`, and `make build`
- `make ROOT=/tmp check`
- Absolute-Makefile invocation from `/tmp`
- Four isolated mutations rejected: overrideable root, missing plan, reopened plan, and missing verification evidence
- `git diff --check`, exact-path review, artifact audit, and changed-line credential scan

## Risk

The change relies on GNU Make semantics already required by the Makefile's existing functions. It does not alter pancake content, source provenance, food-safety guidance, workflows, or the no-scaffold boundary.

## Follow-Ups

Merge the stacked base PR first. Do not merge or close this PR without repository-owner authorization.
