### PR TITLE
docs: pin canonical FDA allergen source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Replaced a redirected FDA food-allergy citation with its canonical HTTPS
+  location and made the content gate reject the retired path.
+
 ## 2026-06-13
 
 - Made content verification independent of the caller's working directory by

--- a/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md
+++ b/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md
@@ -1,0 +1,125 @@
+---
+title: Canonical FDA Allergen Source
+type: security
+date: 2026-06-14
+status: planned
+execution: code
+---
+
+# Canonical FDA Allergen Source
+
+## Summary
+
+Replace the redirected FDA food-allergy citation with its current canonical
+HTTPS location and make the content baseline reject restoration of the retired
+path.
+
+## Problem Frame
+
+The substitution guidance links to an official FDA page through an obsolete
+path that now redirects to a different canonical location. Redirects can hide
+source drift and make future content review less reliable even when the target
+guidance remains authoritative.
+
+## Requirements
+
+- **R1.** `pancakes.md` must cite the current canonical FDA food-allergy URL.
+- **R2.** The content baseline must require the canonical URL and reject the
+  retired redirecting path.
+- **R3.** Existing allergen, cross-contact, and substitution guidance must
+  remain unchanged in meaning.
+- **R4.** The completed plan and change record must capture the source review
+  and its verification evidence.
+
+## Key Technical Decisions
+
+- **Pin the canonical HTTPS page:** the FDA page remains the authoritative
+  source, so only its redirecting path changes.
+- **Use positive and negative static contracts:** requiring the canonical URL
+  alone would not prevent both URLs from coexisting after a future edit.
+- **Keep network access outside `make check`:** hosted and local verification
+  stays deterministic while source freshness remains an explicit maintenance
+  review responsibility.
+
+## Assumptions
+
+- The FDA canonical path observed on 2026-06-14 is the maintained replacement
+  for the retired citation path.
+- No prose change is needed because the source still supports label review and
+  cross-contact guidance.
+
+## Scope Boundaries
+
+- Do not revise recipe ratios, substitution recommendations, or event-serving
+  guidance.
+- Do not add a general-purpose network link checker to the deterministic gate.
+- Do not introduce an application, package dependency, or publishing scaffold.
+
+## Implementation Units
+
+### U1. Canonicalize the FDA citation
+
+**Goal:** Point substitution guidance directly at the maintained FDA page.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:** `pancakes.md`, `CHANGES.md`
+
+**Approach:** Replace only the obsolete FDA path and record the source
+maintenance change without altering the surrounding safety claims.
+
+**Test scenarios:**
+
+- The canonical FDA URL appears once in the substitution source list.
+- The retired FDA URL no longer appears in tracked content.
+- Existing allergen and cross-contact sentences remain present.
+
+**Verification:** Exact diff review shows a source-only content change plus its
+change-log entry.
+
+### U2. Enforce canonical source provenance
+
+**Goal:** Make future source drift fail the existing content baseline.
+
+**Requirements:** R2, R4
+
+**Dependencies:** U1
+
+**Files:** `scripts/check-baseline.sh`,
+`docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md`
+
+**Approach:** Require the canonical URL in the substitution contract, reject
+the retired path anywhere in tracked Markdown content, and require completed
+plan verification evidence.
+
+**Test scenarios:**
+
+- The unchanged repository passes `make check` from the repository root and an
+  external working directory.
+- Replacing the canonical URL with the retired path fails the baseline.
+- Adding the retired path beside the canonical URL fails the baseline.
+- Reopening the completed plan or removing its verification evidence fails the
+  baseline.
+
+**Verification:** Focused static checks, the full content gate, and isolated
+hostile mutations all reject weakened source provenance.
+
+## Risks And Dependencies
+
+- The FDA may move the page again; future source review must update the content,
+  contract, and evidence together.
+- A deterministic static gate proves repository provenance, not live network
+  availability.
+
+## Sources And Research
+
+- FDA, "Food Allergies," current canonical page observed 2026-06-14:
+  https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/food-allergies
+- The prior path redirected to the canonical page during the same review:
+  https://www.fda.gov/food/food-labeling-nutrition/food-allergies
+
+## Verification
+
+Pending implementation.

--- a/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md
+++ b/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md
@@ -2,7 +2,7 @@
 title: Canonical FDA Allergen Source
 type: security
 date: 2026-06-14
-status: planned
+status: completed
 execution: code
 ---
 
@@ -117,9 +117,16 @@ hostile mutations all reject weakened source provenance.
 
 - FDA, "Food Allergies," current canonical page observed 2026-06-14:
   https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/food-allergies
-- The prior path redirected to the canonical page during the same review:
-  https://www.fda.gov/food/food-labeling-nutrition/food-allergies
+- The prior FDA food-labeling path redirected to the canonical page during the
+  same review and is intentionally omitted from tracked Markdown content.
 
 ## Verification
 
-Pending implementation.
+- The canonical FDA page and its current label and cross-contact guidance were
+  reviewed on 2026-06-14 before implementation.
+- `make check` passed from the repository root and an external working
+  directory through the absolute Makefile path.
+- Four isolated hostile mutations were rejected for canonical-link removal,
+  retired-link coexistence, plan reopening, and source-review evidence removal.
+- Shell syntax, all four Make gates, exact diff review, and final artifact and
+  secret audits passed before delivery.

--- a/pancakes.md
+++ b/pancakes.md
@@ -45,7 +45,7 @@ about-8-pancake ratio before scaling an adapted batch for a group.
 - University of Minnesota Extension explains egg functions and replacement
   tradeoffs: https://extension.umn.edu/family-news/egg-substitutions-baking
 - FDA food-allergy guidance covers current labels and cross-contact:
-  https://www.fda.gov/food/food-labeling-nutrition/food-allergies
+  https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/food-allergies
 
 ## Batch Scaling Table
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -20,6 +20,7 @@ SUBSTITUTION_PLAN="$ROOT_DIR/docs/plans/2026-06-13-pancake-substitution-guidance
 SOURCE_PROVENANCE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-source-provenance-boundary.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 MAKE_ROOT_PROTECTION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-make-root-override-protection.md"
+CANONICAL_ALLERGEN_SOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -55,6 +56,7 @@ for path in \
   "docs/plans/2026-06-13-source-provenance-boundary.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-14-make-root-override-protection.md" \
+  "docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
@@ -360,12 +362,13 @@ if ! grep -Fq "1 cup flour" "$ROOT_DIR/pancakes.md" ||
   exit 1
 fi
 
-python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+python3 - "$ROOT_DIR/pancakes.md" "$ROOT_DIR" <<'PY'
 import re
 import sys
 from pathlib import Path
 
 content = Path(sys.argv[1]).read_text()
+root = Path(sys.argv[2])
 section = content.split("## Ingredient Substitutions\n", 1)[-1].split(
     "## Batch Scaling Table", 1
 )[0]
@@ -384,12 +387,23 @@ required = (
     "Check current ingredient and advisory labels every time",
     "control cross-contact from prep surfaces, utensils, and equipment",
     "https://extension.umn.edu/family-news/egg-substitutions-baking",
-    "https://www.fda.gov/food/food-labeling-nutrition/food-allergies",
+    "https://www.fda.gov/food/nutrition-food-labeling-and-critical-foods/food-allergies",
 )
 
 if any(fragment not in normalized for fragment in required):
     raise SystemExit(
         "pancakes.md must keep source-backed, function-aware substitution guidance."
+    )
+
+retired_url = "https://www.fda.gov/food/food-labeling-nutrition/food-allergies"
+retired_matches = [
+    str(path.relative_to(root))
+    for path in root.rglob("*.md")
+    if retired_url in path.read_text()
+]
+if retired_matches:
+    raise SystemExit(
+        "Retired FDA food-allergy URL remains in: " + ", ".join(retired_matches)
     )
 PY
 
@@ -671,6 +685,15 @@ if ! grep -Fq "credential-free HTTPS URLs on approved official" "$ROOT_DIR/READM
   ! grep -Fq "structurally validates source URLs" "$ROOT_DIR/VISION.md" ||
   ! grep -Fq "Added structural source provenance checks" "$ROOT_DIR/CHANGES.md"; then
   printf '%s\n' "Project guidance must preserve the source provenance boundary." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$CANONICAL_ALLERGEN_SOURCE_PLAN" ||
+  ! grep -Fq "repository root" "$CANONICAL_ALLERGEN_SOURCE_PLAN" ||
+  ! grep -Fq "external working directory" "$CANONICAL_ALLERGEN_SOURCE_PLAN" ||
+  ! grep -Fq "isolated hostile mutations" "$CANONICAL_ALLERGEN_SOURCE_PLAN" ||
+  ! grep -Fq "canonical FDA page" "$CANONICAL_ALLERGEN_SOURCE_PLAN"; then
+  printf '%s\n' "Canonical FDA allergen source plan must record completed verification." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Food-allergy guidance now links directly to the FDA's maintained canonical page instead of relying on a retired redirect. The deterministic content gate also prevents that obsolete path from returning unnoticed.

## Baseline

The substitution section cited an official FDA URL that now redirects to a different canonical path. Existing checks required the stale URL and could not detect coexistence of old and new citations.

## Improvements

- Pin the current canonical HTTPS FDA food-allergy source.
- Require the canonical citation and reject the retired path across Markdown content.
- Record the source review, completed verification, and four mutation-sensitive regression cases.

## Validation

- `sh -n scripts/check-baseline.sh`
- `make lint`, `make test`, `make build`, and `make check`
- External-directory `make check` through the absolute Makefile path
- Four isolated hostile mutations covering canonical removal, retired-link coexistence, plan reopening, and evidence removal
- Exact diff, generated-artifact, non-ASCII addition, and credential-pattern audits

## Risk

This is a documentation and deterministic-checker change with no application runtime or deployment impact. FDA source locations can change again, so future source review must update content and contracts together.

## Follow-Ups

- Continue periodic review of authoritative food-safety and allergen sources.
- Keep the existing no-scaffold boundary until a concrete publishing plan exists.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this repository has no deployed runtime. After merge, the owner should confirm the default-branch `check` workflow remains green; any source-contract failure is the rollback or correction trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
