### PR TITLE
fix: preflight Python content verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,8 @@ food safety. It intentionally has no application or dependency scaffold.
 - Lint/static checks: `make lint`
 - Tests: `make test`
 - Build: `make build`
+- The content gate requires GNU Make, a POSIX shell, and Python 3. Override the
+  interpreter command with `make PYTHON=/path/to/python3 check` when needed.
 - If a command above skips because a platform toolchain is missing, verify on a machine with that SDK before claiming platform behavior is tested.
 
 ## Coding conventions

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-16
+
+- The content gate requires GNU Make, a POSIX shell, and Python 3. Added an
+  explicit interpreter override and actionable missing or incompatible runtime
+  diagnostics.
+
 ## 2026-06-14
 
 - Replaced a redirected FDA food-allergy citation with its canonical HTTPS

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: build check lint test
 
 override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PYTHON ?= python3
 
 check:
-	@"$(ROOT)/scripts/check-baseline.sh"
+	@PYTHON="$(PYTHON)" "$(ROOT)/scripts/check-baseline.sh"
 
 lint: check
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Additional scan context:
 ### Prerequisites
 
 - Git
+- GNU Make
+- A POSIX shell
+- Python 3
 
 ### Setup
 
@@ -55,6 +58,10 @@ Run the content baseline:
 ```bash
 make check
 ```
+
+The content gate requires GNU Make, a POSIX shell, and Python 3. It uses the
+`python3` command by default; set `PYTHON=/path/to/python3` on the Make command
+line when a compatible interpreter has a different name or location.
 
 Use the absolute Makefile path to run the same gate from another working
 directory. Verification resolves the checker relative to the loaded Makefile

--- a/VISION.md
+++ b/VISION.md
@@ -24,6 +24,8 @@ Current baseline:
 
 - `scripts/check-baseline.sh` and `make check` verify the content-only
   repository shape.
+- The content gate requires GNU Make, a POSIX shell, and Python 3. Its
+  interpreter command is explicit and fails fast when missing or incompatible.
 - The baseline rejects dependency manifests, lockfiles, source scaffolds, and
   generated dependency directories unless a new plan changes the repository
   scope.

--- a/docs/plans/2026-06-16-python-verification-preflight.md
+++ b/docs/plans/2026-06-16-python-verification-preflight.md
@@ -1,0 +1,60 @@
+# Python Verification Preflight
+
+## Status: In Progress
+
+## Context
+
+The content baseline embeds Python checks for source provenance and batch-table
+structure, but the documented prerequisites list only Git. The checker invokes
+`python3` directly, so a workstation without that command receives a generic
+shell failure and cannot select another compatible Python 3 interpreter.
+
+## Prioritized Engineering Tasks
+
+1. Make the baseline's Python 3 dependency explicit, configurable, and
+   fail-fast with an actionable diagnostic.
+2. Refresh `docs/readme-overview.svg`, whose generated labels predate the
+   maintained Make and hosted verification surfaces.
+3. Evaluate an offline link-integrity contract for maintained internal links
+   without turning external network availability into a content-gate failure.
+
+This plan implements item 1 because it affects every verification run and can
+be proven entirely from repository-local behavior.
+
+## Objectives
+
+- Define one Make-level Python command with a `python3` default.
+- Pass the selected command into the baseline checker without weakening root
+  path protection.
+- Fail before embedded Python checks when the command is absent or is not
+  Python 3.
+- Document GNU Make, a POSIX shell, and Python 3 as baseline prerequisites,
+  including the supported command override.
+- Add static and behavioral contracts that reject missing preflight logic,
+  ignored overrides, and incomplete completion evidence.
+
+## Scope
+
+- Update `Makefile`, `scripts/check-baseline.sh`, `README.md`, `AGENTS.md`,
+  `VISION.md`, and `CHANGES.md`.
+- Extend the maintained baseline and this plan's completion evidence.
+- Do not change `pancakes.md`, food-safety guidance, sources, dependencies,
+  hosted permissions, or repository publishing posture.
+
+## Verification
+
+- Run POSIX shell syntax validation.
+- Run all four Make aliases from the repository root with the default Python.
+- Run `make check` from an external directory using the absolute Makefile path.
+- Run the gate through an explicit compatible Python command override.
+- Prove missing and non-Python-3 commands fail with the intended diagnostic.
+- Reject isolated mutations covering command propagation, preflight behavior,
+  documentation, and completed-plan evidence.
+- Audit exact paths, generated artifacts, credential-like values, dependency
+  drift, conflict markers, file modes, and whitespace.
+
+## Runtime Boundary
+
+Verification is offline and content-only. No recipe execution, food-service
+environment, browser, external source refresh, or network-dependent validation
+is performed or claimed.

--- a/docs/plans/2026-06-16-python-verification-preflight.md
+++ b/docs/plans/2026-06-16-python-verification-preflight.md
@@ -1,6 +1,6 @@
 # Python Verification Preflight
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -58,3 +58,34 @@ be proven entirely from repository-local behavior.
 Verification is offline and content-only. No recipe execution, food-service
 environment, browser, external source refresh, or network-dependent validation
 is performed or claimed.
+
+## Work Completed
+
+- Added a Make-level `PYTHON` command with a `python3` default and quoted
+  propagation into the content checker.
+- Added missing-command and major-version preflights before any embedded Python
+  validation, with actionable diagnostics for each failure mode.
+- Routed all seven embedded Python checks through the preflighted interpreter.
+- Documented the GNU Make, POSIX shell, and Python 3 prerequisites and the
+  explicit compatible Python command override.
+- Added mutation-sensitive baseline contracts for command propagation,
+  executable preflight behavior, embedded-call ownership, documentation, and
+  this completed evidence record.
+
+## Verification Completed
+
+- POSIX shell syntax validation passed.
+- All four Make aliases passed from the repository root with Python 3.12.8.
+- `make check` passed from the repository root and external working directory.
+- The explicit compatible Python command override passed using the resolved
+  Python 3 executable path.
+- The missing-command and non-Python-3 preflights failed early with their
+  intended actionable diagnostics.
+- Nine isolated hostile mutations were rejected for the Make default,
+  propagation, command lookup, major-version comparison, embedded-call
+  routing, diagnostic, prerequisite guidance, plan status, and override
+  evidence contracts.
+- Exact diff, generated-artifact, credential-like value, dependency drift,
+  conflict-marker, file-mode, and whitespace audits passed.
+- No recipe execution, food-service environment, browser, external source
+  refresh, or network-dependent validation was performed or claimed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -21,7 +21,20 @@ SOURCE_PROVENANCE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-source-provenance-bounda
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 MAKE_ROOT_PROTECTION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-make-root-override-protection.md"
 CANONICAL_ALLERGEN_SOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md"
+PYTHON_PREFLIGHT_PLAN="$ROOT_DIR/docs/plans/2026-06-16-python-verification-preflight.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
+PYTHON=${PYTHON:-python3}
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  printf '%s\n' "Python 3 command not found: $PYTHON (set PYTHON to a Python 3 executable)." >&2
+  exit 1
+fi
+
+python_major=$("$PYTHON" -c 'import sys; sys.stdout.write(str(sys.version_info[0]))' 2>/dev/null || true)
+if [ "$python_major" != "3" ]; then
+  printf '%s\n' "Verification requires Python 3: $PYTHON" >&2
+  exit 1
+fi
 
 require_file() {
   path=$1
@@ -57,14 +70,36 @@ for path in \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-14-make-root-override-protection.md" \
   "docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md" \
+  "docs/plans/2026-06-16-python-verification-preflight.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md"; do
   require_file "$path"
 done
 
 if ! grep -Fq 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
-  ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
+  ! grep -Fq 'PYTHON ?= python3' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq 'PYTHON="$(PYTHON)" "$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
   printf '%s\n' "Makefile verification must protect and resolve the checker from the loaded Makefile." >&2
+  exit 1
+fi
+
+python_preflight=$(sed -n '/^PYTHON=${PYTHON:-python3}$/,/^require_file()/p' "$ROOT_DIR/scripts/check-baseline.sh")
+for python_preflight_contract in \
+  'PYTHON=${PYTHON:-python3}' \
+  'command -v "$PYTHON"' \
+  'sys.stdout.write(str(sys.version_info[0]))' \
+  'if [ "$python_major" != "3" ]; then' \
+  'Python 3 command not found:' \
+  'Verification requires Python 3:'; do
+  if ! printf '%s\n' "$python_preflight" | grep -Fq "$python_preflight_contract"; then
+    printf '%s\n' "Python verification preflight contract is missing: $python_preflight_contract" >&2
+    exit 1
+  fi
+done
+
+if [ "$(grep -Ec '^"\$PYTHON" - ' "$ROOT_DIR/scripts/check-baseline.sh")" -ne 7 ] ||
+  grep -Eq '^python3 - ' "$ROOT_DIR/scripts/check-baseline.sh"; then
+  printf '%s\n' "Every embedded Python check must use the preflighted interpreter command." >&2
   exit 1
 fi
 
@@ -271,7 +306,7 @@ if [ "$bullet_count" -lt 20 ]; then
   exit 1
 fi
 
-python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+"$PYTHON" - "$ROOT_DIR/pancakes.md" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -315,7 +350,7 @@ if observed_hosts != approved_hosts:
     raise SystemExit(f"pancakes.md must retain every reviewed source host: {missing}")
 PY
 
-python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+"$PYTHON" - "$ROOT_DIR/pancakes.md" <<'PY'
 import sys
 from pathlib import Path
 
@@ -362,7 +397,7 @@ if ! grep -Fq "1 cup flour" "$ROOT_DIR/pancakes.md" ||
   exit 1
 fi
 
-python3 - "$ROOT_DIR/pancakes.md" "$ROOT_DIR" <<'PY'
+"$PYTHON" - "$ROOT_DIR/pancakes.md" "$ROOT_DIR" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -501,7 +536,7 @@ if ! grep -Fq "Pour one 1/4 cup test pancake" "$ROOT_DIR/pancakes.md" ||
   exit 1
 fi
 
-python3 - "$ROOT_DIR/pancakes.md" <<'PY'
+"$PYTHON" - "$ROOT_DIR/pancakes.md" <<'PY'
 import sys
 from pathlib import Path
 
@@ -602,7 +637,7 @@ if ! grep -Fq "status: completed" "$CI_PLAN" ||
   exit 1
 fi
 
-python3 - "$BATCH_SCALING_PLAN" <<'PY'
+"$PYTHON" - "$BATCH_SCALING_PLAN" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -629,7 +664,7 @@ if (
     )
 PY
 
-python3 - "$CALIBRATION_PLAN" <<'PY'
+"$PYTHON" - "$CALIBRATION_PLAN" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -650,7 +685,7 @@ if statuses != ["status: completed"] or any(item not in plan for item in require
     )
 PY
 
-python3 - "$SUBSTITUTION_PLAN" <<'PY'
+"$PYTHON" - "$SUBSTITUTION_PLAN" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -696,5 +731,24 @@ if ! grep -Fq "status: completed" "$CANONICAL_ALLERGEN_SOURCE_PLAN" ||
   printf '%s\n' "Canonical FDA allergen source plan must record completed verification." >&2
   exit 1
 fi
+
+for python_preflight_doc in README.md AGENTS.md VISION.md CHANGES.md; do
+  if ! grep -Fq "The content gate requires GNU Make, a POSIX shell, and Python 3." "$ROOT_DIR/$python_preflight_doc"; then
+    printf '%s\n' "$python_preflight_doc must document the Python verification prerequisite." >&2
+    exit 1
+  fi
+done
+
+for python_preflight_plan_contract in \
+  "## Status: Completed" \
+  "repository root and external working directory" \
+  "explicit compatible Python command override" \
+  "missing-command and non-Python-3 preflights" \
+  "hostile mutations were rejected"; do
+  if ! grep -Fq "$python_preflight_plan_contract" "$PYTHON_PREFLIGHT_PLAN"; then
+    printf '%s\n' "Python verification preflight plan must record completed evidence: $python_preflight_plan_contract" >&2
+    exit 1
+  fi
+done
 
 printf '%s\n' "fantastic-pancake content baseline checks passed."


### PR DESCRIPTION
## Summary

Content verification now fails immediately with an actionable message when its Python runtime is missing or incompatible, instead of failing later inside an embedded check. Contributors can select any compatible Python 3 executable through the documented `PYTHON` Make variable, while all seven embedded validations remain bound to the preflighted interpreter.

This is stacked on PR #11 and must retain base-first merge ordering.

## Validation

- `sh -n scripts/check-baseline.sh`
- `make check`, `make lint`, `make test`, and `make build`
- external-directory `make -f <absolute Makefile path> check`
- explicit resolved Python 3 command override
- missing-command and non-Python-command negative cases
- nine isolated hostile mutations rejected
- exact diff, artifact, credential, dependency, conflict-marker, file-mode, and whitespace audits
- plan-aware review: zero actionable findings

## Runtime Boundary

Validation is offline and content-only. No recipe execution, food-service environment, browser, external source refresh, or network-dependent validation was performed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this repository has no deployed runtime. The canonical push and pull-request content checks on the exact head are the healthy signal; any failed gate should block merge and be repaired without weakening the baseline.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.4-000000)
