### PR TITLE
fix: validate offline Markdown link targets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-16
 
+- Offline verification checks relative Markdown link and image targets without requesting external URLs.
 - The content gate requires GNU Make, a POSIX shell, and Python 3. Added an
   explicit interpreter override and actionable missing or incompatible runtime
   diagnostics.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The `make lint`, `make test`, and `make build` aliases run the same content
 baseline while this repository has no narrower installed gates.
 GitHub Actions runs `make check` for pushes and pull requests with read-only
 repository permissions and does not persist checkout credentials.
+Offline verification checks relative Markdown link and image targets without requesting external URLs.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+Offline verification checks relative Markdown link and image targets without requesting external URLs.
+
 ## Supported Versions
 
 The supported security scope for `fantastic-pancake` is the current default branch, `main`. Older commits, tags, branches, forks, demos, and generated artifacts are not actively supported unless the repository explicitly marks them as maintained.

--- a/VISION.md
+++ b/VISION.md
@@ -2,6 +2,7 @@
 
 This document explains the current state and direction of the project.
 Project overview and developer docs: [`README.md`](README.md)
+Offline verification checks relative Markdown link and image targets without requesting external URLs.
 
 Fantastic Pancake is a lightweight repository about pancakes. It currently
 contains a simple `pancakes.md` outline covering a basic method, pancake types,

--- a/docs/plans/2026-06-16-offline-internal-link-integrity.md
+++ b/docs/plans/2026-06-16-offline-internal-link-integrity.md
@@ -39,13 +39,14 @@ gate.
 
 ## Verification Completed
 
-- `python3 scripts/test-internal-links.py` passed four focused temporary-tree
+- `python3 scripts/test-internal-links.py` passed six focused temporary-tree
   regressions.
 - `python3 scripts/check-internal-links.py .` passed all maintained Markdown
   references without performing a network request.
-- Six isolated internal-link mutations were rejected: a missing image target,
+- Eight isolated internal-link mutations were rejected: a missing image target,
   repository escape, removed external-scheme skip, removed checker invocation,
-  missing guidance, and reopened plan status each failed the gate.
+  missing guidance, reopened plan status, disabled inline-code suppression, and
+  disabled reference-definition validation each failed the gate.
 - `make check` passed from the repository root and external working directory
   with the preflighted Python 3 command.
 - No external URL request, browser rendering, recipe execution, or food-safety

--- a/docs/plans/2026-06-16-offline-internal-link-integrity.md
+++ b/docs/plans/2026-06-16-offline-internal-link-integrity.md
@@ -1,0 +1,52 @@
+# Offline Internal Link Integrity
+
+## Status: In Progress
+
+## Context
+
+The content baseline requires maintained files but does not validate relative
+Markdown link and image destinations. A rename or typo can therefore leave the
+README overview image or a cross-document reference broken while `make check`
+still passes. External source availability must remain outside the offline
+gate.
+
+## Objectives
+
+- Validate local Markdown link and image targets across maintained Markdown.
+- Reject missing targets and repository-escaping relative paths.
+- Skip absolute web, mail, telephone, and same-document fragment links without
+  performing network requests.
+- Keep verification location-independent and routed through the preflighted
+  Python 3 command.
+- Add mutation-sensitive checker, guidance, and completed-plan contracts.
+
+## Scope
+
+- Add a dependency-free Python link-target validator under `scripts/`.
+- Invoke it from `scripts/check-baseline.sh` and require its static contracts.
+- Document the offline link-integrity boundary in `README.md`, `SECURITY.md`,
+  `VISION.md`, and `CHANGES.md`.
+
+## Verification
+
+- Python syntax and focused link checker
+- Repository-root and external-directory `make check`
+- Isolated mutations for a missing image target, repository escape, checker
+  invocation, external-link skipping, guidance, and completed-plan evidence
+- `git diff --check`
+- Exact-path, generated-artifact, sensitive-value, conflict-marker, and
+  file-mode audits
+
+## Risks
+
+- Markdown destination parsing must not turn external availability into a
+  build dependency.
+- URL fragments and query strings must not be treated as filesystem path text.
+- No recipe execution, browser rendering, or external URL request will be
+  performed.
+- This PR is stacked on PR #12 and must retain base-first merge ordering.
+
+## Out Of Scope
+
+- External link health, heading-anchor validation, generated SVG refreshes,
+  recipe wording, food-safety guidance, and dependency additions.

--- a/docs/plans/2026-06-16-offline-internal-link-integrity.md
+++ b/docs/plans/2026-06-16-offline-internal-link-integrity.md
@@ -1,6 +1,6 @@
 # Offline Internal Link Integrity
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -36,6 +36,20 @@ gate.
 - `git diff --check`
 - Exact-path, generated-artifact, sensitive-value, conflict-marker, and
   file-mode audits
+
+## Verification Completed
+
+- `python3 scripts/test-internal-links.py` passed four focused temporary-tree
+  regressions.
+- `python3 scripts/check-internal-links.py .` passed all maintained Markdown
+  references without performing a network request.
+- Six isolated internal-link mutations were rejected: a missing image target,
+  repository escape, removed external-scheme skip, removed checker invocation,
+  missing guidance, and reopened plan status each failed the gate.
+- `make check` passed from the repository root and external working directory
+  with the preflighted Python 3 command.
+- No external URL request, browser rendering, recipe execution, or food-safety
+  wording change was performed.
 
 ## Risks
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -22,6 +22,9 @@ LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-indepen
 MAKE_ROOT_PROTECTION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-make-root-override-protection.md"
 CANONICAL_ALLERGEN_SOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md"
 PYTHON_PREFLIGHT_PLAN="$ROOT_DIR/docs/plans/2026-06-16-python-verification-preflight.md"
+INTERNAL_LINK_PLAN="$ROOT_DIR/docs/plans/2026-06-16-offline-internal-link-integrity.md"
+INTERNAL_LINK_CHECKER="$ROOT_DIR/scripts/check-internal-links.py"
+INTERNAL_LINK_TEST="$ROOT_DIR/scripts/test-internal-links.py"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 PYTHON=${PYTHON:-python3}
 
@@ -71,10 +74,29 @@ for path in \
   "docs/plans/2026-06-14-make-root-override-protection.md" \
   "docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md" \
   "docs/plans/2026-06-16-python-verification-preflight.md" \
+  "docs/plans/2026-06-16-offline-internal-link-integrity.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
-  "docs/plans/2026-06-10-hosted-content-checks.md"; do
+  "docs/plans/2026-06-10-hosted-content-checks.md" \
+  "scripts/check-internal-links.py" \
+  "scripts/test-internal-links.py"; do
   require_file "$path"
 done
+
+"$PYTHON" "$INTERNAL_LINK_TEST"
+"$PYTHON" "$INTERNAL_LINK_CHECKER" "$ROOT_DIR"
+
+if [ "$(grep -Fxc '"$PYTHON" "$INTERNAL_LINK_TEST"' "$ROOT_DIR/scripts/check-baseline.sh")" -ne 1 ] ||
+  [ "$(grep -Fxc '"$PYTHON" "$INTERNAL_LINK_CHECKER" "$ROOT_DIR"' "$ROOT_DIR/scripts/check-baseline.sh")" -ne 1 ] ||
+  ! grep -Fq 'def validate_repository(root: Path) -> list[str]:' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'local link escapes repository' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'local link target does not exist' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'if parsed.scheme or parsed.netloc:' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'test_rejects_missing_local_target' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_rejects_repository_escape' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_ignores_links_inside_fenced_examples' "$INTERNAL_LINK_TEST"; then
+  printf '%s\n' "Offline internal-link verification contracts are incomplete." >&2
+  exit 1
+fi
 
 if ! grep -Fq 'override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
   ! grep -Fq 'PYTHON ?= python3' "$ROOT_DIR/Makefile" ||
@@ -747,6 +769,25 @@ for python_preflight_plan_contract in \
   "hostile mutations were rejected"; do
   if ! grep -Fq "$python_preflight_plan_contract" "$PYTHON_PREFLIGHT_PLAN"; then
     printf '%s\n' "Python verification preflight plan must record completed evidence: $python_preflight_plan_contract" >&2
+    exit 1
+  fi
+done
+
+internal_link_guidance='Offline verification checks relative Markdown link and image targets without requesting external URLs.'
+for internal_link_doc in README.md SECURITY.md VISION.md CHANGES.md; do
+  if ! grep -Fq "$internal_link_guidance" "$ROOT_DIR/$internal_link_doc"; then
+    printf '%s\n' "$internal_link_doc must document offline internal-link verification." >&2
+    exit 1
+  fi
+done
+
+for internal_link_plan_contract in \
+  "## Status: Completed" \
+  "repository root and external working directory" \
+  "isolated internal-link mutations were rejected" \
+  "No external URL request"; do
+  if ! grep -Fq "$internal_link_plan_contract" "$INTERNAL_LINK_PLAN"; then
+    printf '%s\n' "Offline internal-link plan must record completed evidence: $internal_link_plan_contract" >&2
     exit 1
   fi
 done

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -93,7 +93,9 @@ if [ "$(grep -Fxc '"$PYTHON" "$INTERNAL_LINK_TEST"' "$ROOT_DIR/scripts/check-bas
   ! grep -Fq 'if parsed.scheme or parsed.netloc:' "$INTERNAL_LINK_CHECKER" ||
   ! grep -Fq 'test_rejects_missing_local_target' "$INTERNAL_LINK_TEST" ||
   ! grep -Fq 'test_rejects_repository_escape' "$INTERNAL_LINK_TEST" ||
-  ! grep -Fq 'test_ignores_links_inside_fenced_examples' "$INTERNAL_LINK_TEST"; then
+  ! grep -Fq 'test_ignores_links_inside_fenced_examples' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_ignores_link_syntax_inside_inline_code' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_rejects_missing_reference_definition_target' "$INTERNAL_LINK_TEST"; then
   printf '%s\n' "Offline internal-link verification contracts are incomplete." >&2
   exit 1
 fi

--- a/scripts/check-internal-links.py
+++ b/scripts/check-internal-links.py
@@ -11,6 +11,9 @@ from urllib.parse import unquote, urlsplit
 LINK_PATTERN = re.compile(
     r"!?\[[^\]]*\]\(\s*(?P<destination><[^>]+>|[^\s)]+)"
 )
+REFERENCE_PATTERN = re.compile(
+    r"^\s{0,3}\[[^\]]+\]:\s*(?P<destination><[^>]+>|\S+)"
+)
 
 
 def is_within_root(path: Path, root: Path) -> bool:
@@ -27,6 +30,38 @@ def markdown_files(root: Path):
             yield path
 
 
+def without_code_spans(line: str) -> str:
+    visible = list(line)
+    position = 0
+    while True:
+        start = line.find("`", position)
+        if start < 0:
+            break
+
+        marker_end = start
+        while marker_end < len(line) and line[marker_end] == "`":
+            marker_end += 1
+        marker = line[start:marker_end]
+        end = line.find(marker, marker_end)
+        if end < 0:
+            break
+
+        visible[start : end + len(marker)] = " " * (end + len(marker) - start)
+        position = end + len(marker)
+
+    return "".join(visible)
+
+
+def destinations(line: str):
+    visible = without_code_spans(line)
+    for match in LINK_PATTERN.finditer(visible):
+        yield match.group("destination")
+
+    reference = REFERENCE_PATTERN.match(visible)
+    if reference:
+        yield reference.group("destination")
+
+
 def validate_repository(root: Path) -> list[str]:
     root = root.resolve()
     failures: list[str] = []
@@ -41,8 +76,8 @@ def validate_repository(root: Path) -> list[str]:
             if in_fence:
                 continue
 
-            for match in LINK_PATTERN.finditer(line):
-                destination = match.group("destination").strip("<>")
+            for raw_destination in destinations(line):
+                destination = raw_destination.strip("<>")
                 if destination.startswith("#") or destination.startswith("//"):
                     continue
 

--- a/scripts/check-internal-links.py
+++ b/scripts/check-internal-links.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+LINK_PATTERN = re.compile(
+    r"!?\[[^\]]*\]\(\s*(?P<destination><[^>]+>|[^\s)]+)"
+)
+
+
+def is_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def markdown_files(root: Path):
+    for path in sorted(root.rglob("*.md")):
+        if ".git" not in path.parts:
+            yield path
+
+
+def validate_repository(root: Path) -> list[str]:
+    root = root.resolve()
+    failures: list[str] = []
+
+    for source in markdown_files(root):
+        in_fence = False
+        for line_number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+
+            for match in LINK_PATTERN.finditer(line):
+                destination = match.group("destination").strip("<>")
+                if destination.startswith("#") or destination.startswith("//"):
+                    continue
+
+                parsed = urlsplit(destination)
+                if parsed.scheme or parsed.netloc:
+                    continue
+                if not parsed.path or parsed.path.startswith("/"):
+                    continue
+
+                target = (source.parent / unquote(parsed.path)).resolve()
+                location = f"{source.relative_to(root)}:{line_number}"
+                if not is_within_root(target, root):
+                    failures.append(
+                        f"{location}: local link escapes repository: {destination}"
+                    )
+                elif not target.exists():
+                    failures.append(
+                        f"{location}: local link target does not exist: {destination}"
+                    )
+
+    return failures
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check-internal-links.py <repository-root>", file=sys.stderr)
+        return 2
+
+    failures = validate_repository(Path(sys.argv[1]))
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+
+    print("Offline internal Markdown link checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-internal-links.py
+++ b/scripts/test-internal-links.py
@@ -61,6 +61,19 @@ class InternalLinkChecks(unittest.TestCase):
         )
         self.assertEqual(failures, [])
 
+    def test_ignores_link_syntax_inside_inline_code(self):
+        failures = self.validate(
+            {"README.md": "Use `[Example](missing.md)` as sample syntax.\n"}
+        )
+        self.assertEqual(failures, [])
+
+    def test_rejects_missing_reference_definition_target(self):
+        failures = self.validate(
+            {"README.md": "[Guide][guide]\n\n[guide]: docs/missing.md\n"}
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertIn("local link target does not exist", failures[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test-internal-links.py
+++ b/scripts/test-internal-links.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CHECKER_PATH = Path(__file__).with_name("check-internal-links.py")
+sys.dont_write_bytecode = True
+SPEC = importlib.util.spec_from_file_location("check_internal_links", CHECKER_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("Unable to load internal-link checker")
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class InternalLinkChecks(unittest.TestCase):
+    def validate(self, files: dict[str, str]) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative_path, content in files.items():
+                path = root / relative_path
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            return CHECKER.validate_repository(root)
+
+    def test_accepts_existing_targets_and_skips_external_destinations(self):
+        failures = self.validate(
+            {
+                "README.md": (
+                    "[Guide](docs/guide.md?view=1#intro)\n"
+                    "![Overview](docs/overview.svg)\n"
+                    "[Section](#section)\n"
+                    "[Source](https://example.com/guide)\n"
+                    "[Email](mailto:maintainer@example.com)\n"
+                    "[Inline data](data:text/plain,example)\n"
+                ),
+                "docs/guide.md": "# Intro\n",
+                "docs/overview.svg": "<svg/>\n",
+            }
+        )
+        self.assertEqual(failures, [])
+
+    def test_rejects_missing_local_target(self):
+        failures = self.validate({"README.md": "![Overview](docs/missing.svg)\n"})
+        self.assertEqual(len(failures), 1)
+        self.assertIn("local link target does not exist", failures[0])
+
+    def test_rejects_repository_escape(self):
+        failures = self.validate({"README.md": "[Outside](../outside.md)\n"})
+        self.assertEqual(len(failures), 1)
+        self.assertIn("local link escapes repository", failures[0])
+
+    def test_ignores_links_inside_fenced_examples(self):
+        failures = self.validate(
+            {"README.md": "```markdown\n[Example](missing.md)\n```\n"}
+        )
+        self.assertEqual(failures, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Prevent broken relative Markdown links and images from passing the content baseline. The offline validator checks repository-local inline and reference-style targets while deliberately avoiding external network requests.

## Baseline

`make check` previously required maintained files but did not follow Markdown destinations, so a renamed overview image or cross-document target could break rendered documentation without failing CI.

## Improvements

- Add a dependency-free Python validator for inline and reference-style local Markdown links and images.
- Reject missing targets and paths that resolve outside the repository.
- Ignore URI schemes, site-absolute paths, fragments, query strings, fenced examples, and inline code without probing the network.
- Add six temporary-tree regressions and static contracts that require both test and repository-scan invocations.
- Document the offline boundary and completed mutation evidence.

## Validation

- `python3 scripts/test-internal-links.py`
- `python3 scripts/check-internal-links.py .`
- `make check`, `make lint`, `make test`, and `make build` from the repository root
- `make -f /home/gjones/code/private/worktrees/fantastic-pancake-canonical-allergen-source-20260614/Makefile check` from an external working directory, including an explicit Python 3 override
- Eight isolated mutations rejected: missing target, repository escape, removed URI skip, removed invocation, removed guidance, reopened plan, disabled inline-code suppression, and disabled reference-definition validation
- Exact eight-path whitespace, artifact, credential-shaped addition, conflict-marker, and file-mode audits

## Risk

The parser is intentionally offline and line-oriented. It does not validate heading anchors, browser rendering, multiline destination constructs, or external URL health. No recipe or food-safety wording changed.

## Follow-Ups

Refresh `docs/readme-overview.svg` separately if its generated labels drift from maintained verification surfaces. Keep PR #13 stacked on PR #12 and merge base-first only with explicit owner authorization.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this repository has no deployed runtime. The maintainer should confirm the exact-head push and pull-request `check` jobs succeed; any false-positive local-link failure is the rollback trigger for this change while preserving the Python preflight stack.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
