### PR TITLE
fix: validate Markdown heading fragments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 2026-06-16
 
-- Offline verification checks relative Markdown link and image targets without requesting external URLs.
+- Offline verification checks relative Markdown link, image, and heading-fragment targets without requesting external URLs.
 - The content gate requires GNU Make, a POSIX shell, and Python 3. Added an
   explicit interpreter override and actionable missing or incompatible runtime
   diagnostics.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The `make lint`, `make test`, and `make build` aliases run the same content
 baseline while this repository has no narrower installed gates.
 GitHub Actions runs `make check` for pushes and pull requests with read-only
 repository permissions and does not persist checkout credentials.
-Offline verification checks relative Markdown link and image targets without requesting external URLs.
+Offline verification checks relative Markdown link, image, and heading-fragment targets without requesting external URLs.
 
 When the required SDK or runtime is unavailable, use static checks and source review first, then verify on a machine that has the matching platform toolchain.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Offline verification checks relative Markdown link and image targets without requesting external URLs.
+Offline verification checks relative Markdown link, image, and heading-fragment targets without requesting external URLs.
 
 ## Supported Versions
 

--- a/VISION.md
+++ b/VISION.md
@@ -2,7 +2,7 @@
 
 This document explains the current state and direction of the project.
 Project overview and developer docs: [`README.md`](README.md)
-Offline verification checks relative Markdown link and image targets without requesting external URLs.
+Offline verification checks relative Markdown link, image, and heading-fragment targets without requesting external URLs.
 
 Fantastic Pancake is a lightweight repository about pancakes. It currently
 contains a simple `pancakes.md` outline covering a basic method, pancake types,

--- a/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
+++ b/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
@@ -1,6 +1,6 @@
 # Markdown Heading Fragment Integrity
 
-## Status: Planned
+## Status: Completed
 
 ## Summary
 
@@ -38,8 +38,8 @@ heading renames and duplicate-heading reorderings should be caught offline.
 - **R3:** Same-document fragments must be validated against the source document
   instead of being skipped.
 - **R4:** Anchor extraction must ignore fenced code and support ATX headings,
-  setext headings, inline Markdown formatting removal, percent-decoded
-  fragments, and deterministic duplicate suffixes.
+  HTML comments, setext headings, inline Markdown formatting removal,
+  percent-decoded fragments, and deterministic duplicate suffixes.
 - **R5:** Fragments on non-Markdown local targets and absolute external links
   must remain outside the heading-anchor gate.
 - **R6:** Focused tests, the baseline contract, maintained guidance, and this
@@ -194,6 +194,37 @@ the plan records the exact validation actually completed.
 - Duplicate suffixes are order-sensitive, so heading extraction must preserve
   document order and ignore fenced examples.
 - The checker must not turn external availability into a build dependency.
+
+## Work Completed
+
+- Added a cached, dependency-free anchor index for ATX and setext headings,
+  GitHub-style basic slug normalization, deterministic collision suffixes, and
+  explicit custom anchors.
+- Extended local link validation to check decoded same-document and
+  cross-document Markdown fragments only after existing path safety and target
+  existence checks pass.
+- Added focused coverage for valid and missing fragments, duplicate collisions,
+  formatting, setext headings, fenced examples, custom anchors, percent
+  decoding, HTML comments and inline-code comment markers, and non-Markdown
+  fragment preservation.
+- Integrated heading-fragment contracts and synchronized guidance into the
+  maintained offline baseline.
+
+## Verification Completed
+
+- `python3 scripts/test-internal-links.py` passed 14 focused temporary-tree regressions.
+- `python3 scripts/check-internal-links.py .` passed all maintained Markdown.
+- 14 isolated heading-fragment mutations were rejected across fragment gating,
+  duplicate allocation, setext parsing, fence suppression, custom anchors,
+  inline formatting, percent decoding, HTML-comment suppression, inline-code
+  comment markers and custom-anchor examples, checker and test registration,
+  maintained guidance, and completed-plan evidence.
+- `sh -n scripts/check-baseline.sh` and Python compilation passed.
+- `make check`, `make lint`, `make test`, and `make build` passed from the
+  repository root, and the absolute Makefile `check` target passed from an
+  external working directory.
+- No external URL request, browser rendering, recipe execution, generated SVG
+  refresh, or food-safety wording change was performed.
 
 ## Sources And Research
 

--- a/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
+++ b/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
@@ -223,6 +223,8 @@ the plan records the exact validation actually completed.
 - `make check`, `make lint`, `make test`, and `make build` passed from the
   repository root, and the absolute Makefile `check` target passed from an
   external working directory.
+- Push run `27629257088` and pull-request run `27629271024` passed at
+  implementation commit `99e86701f69cfdfbe9c6134d5bcda5767ada2cea`.
 - No external URL request, browser rendering, recipe execution, generated SVG
   refresh, or food-safety wording change was performed.
 

--- a/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
+++ b/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md
@@ -1,0 +1,206 @@
+# Markdown Heading Fragment Integrity
+
+## Status: Planned
+
+## Summary
+
+Extend the dependency-free offline Markdown link checker so local links with
+fragments fail when the referenced GitHub-style heading or explicit custom
+anchor does not exist. Preserve the current filesystem, repository-boundary,
+code-span, fence, reference-link, and external-network behavior.
+
+## Problem Frame
+
+The current checker proves that a relative Markdown target file exists but
+intentionally ignores its URL fragment. Links such as
+`pancakes.md#missing-section` therefore pass even though GitHub renders them as
+broken navigation. The repository now has enough maintained Markdown that
+heading renames and duplicate-heading reorderings should be caught offline.
+
+## Prioritized Engineering Tasks
+
+1. **P0: Validate local Markdown fragments.** Reject same-document and
+   cross-document links whose decoded fragment is absent from the target
+   Markdown document.
+2. **P1: Match GitHub's documented basic anchor rules.** Cover lowercase
+   conversion, space-to-hyphen conversion, punctuation and formatting removal,
+   duplicate-anchor numeric suffixes, and explicit HTML custom anchors.
+3. **P2 follow-up: Broader Markdown rendering fidelity.** Defer multiline link
+   syntax, generated HTML IDs outside explicit anchors, and external URL health
+   until a concrete repository failure requires a fuller parser.
+
+## Requirements
+
+- **R1:** Existing relative path validation must continue to reject missing and
+  repository-escaping targets before fragment validation.
+- **R2:** A fragment on a local Markdown link must resolve against the target
+  file's generated heading anchors or explicit `<a name="...">` anchors.
+- **R3:** Same-document fragments must be validated against the source document
+  instead of being skipped.
+- **R4:** Anchor extraction must ignore fenced code and support ATX headings,
+  setext headings, inline Markdown formatting removal, percent-decoded
+  fragments, and deterministic duplicate suffixes.
+- **R5:** Fragments on non-Markdown local targets and absolute external links
+  must remain outside the heading-anchor gate.
+- **R6:** Focused tests, the baseline contract, maintained guidance, and this
+  plan must make anchor-validation regressions mutation-sensitive.
+
+## Key Technical Decisions
+
+- **Use a dependency-free document index:** the repository intentionally has no
+  package scaffold, and the existing checker already owns offline Markdown
+  structure validation.
+- **Implement GitHub's documented basic heading rules, not a general renderer:**
+  this covers the repository's maintained Markdown without introducing a
+  dependency or claiming complete CommonMark rendering fidelity.
+- **Index each Markdown target once per validation run:** cross-document links
+  should reuse extracted anchors rather than reparsing the same file for every
+  link.
+- **Validate explicit custom anchors separately from generated headings:**
+  custom anchors participate in navigation but do not alter duplicate-heading
+  numbering.
+
+## Scope Boundaries
+
+### In Scope
+
+- Local inline and reference links with same-file or cross-file fragments.
+- ATX and setext heading anchors, duplicate suffixes, inline formatting, custom
+  anchors, and percent-decoded fragments.
+- Focused temporary-tree tests, baseline mutation contracts, and synchronized
+  repository guidance.
+
+### Deferred to Follow-Up Work
+
+- External URL availability, browser rendering, multiline Markdown links,
+  arbitrary raw-HTML element IDs, generated SVG changes, recipe wording, and
+  food-safety guidance.
+
+## Implementation Units
+
+### U1. Build the Markdown anchor index
+
+**Goal:** Derive the navigable anchors for each maintained Markdown document.
+
+**Requirements:** R2, R4
+
+**Dependencies:** None
+
+**Files:**
+
+- `scripts/check-internal-links.py`
+- `scripts/test-internal-links.py`
+
+**Approach:** Add small parsing helpers that reuse the existing fence and
+inline-code boundaries, extract ATX and setext heading text, normalize it using
+GitHub's documented basic rules, assign stable duplicate suffixes in document
+order, and collect explicit custom anchor names without affecting heading
+numbering. Cache the resulting anchor set by resolved Markdown path.
+
+**Execution note:** Start with failing focused tests for normalization,
+duplicates, setext headings, fenced examples, and custom anchors before changing
+the checker.
+
+**Patterns to follow:** Existing dependency-free temporary-tree tests and
+line-oriented fence suppression in `scripts/check-internal-links.py`.
+
+**Test scenarios:**
+
+- A heading `## Basic Pancake Method` produces `basic-pancake-method`.
+- Inline emphasis and punctuation are removed while Unicode letters remain.
+- Repeated identical headings produce the base anchor, then `-1`, then `-2`.
+- A natural heading ending in `-1` cannot collide with a suffix already assigned
+  to an earlier duplicate; every generated anchor remains unique in document
+  order.
+- Setext headings are indexed; heading-like text inside a fence is ignored.
+- `<a name="serving-note"></a>` resolves without changing duplicate heading
+  suffixes.
+
+**Verification:** Focused tests prove the extracted anchor set and ordering for
+each scenario without network access.
+
+### U2. Enforce local fragment resolution
+
+**Goal:** Reject broken local Markdown navigation while preserving current path
+and external-link behavior.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+
+- `scripts/check-internal-links.py`
+- `scripts/test-internal-links.py`
+
+**Approach:** After a local target passes repository-boundary and existence
+checks, validate its decoded fragment only when the resolved target is a
+Markdown file. Resolve an empty path to the source document, report the source
+line and original destination for missing anchors, and leave non-Markdown
+fragments and external schemes unchanged.
+
+**Test scenarios:**
+
+- Existing same-document and cross-document heading fragments pass.
+- A missing same-document fragment and a missing cross-document fragment each
+  produce one anchor-specific failure at the source line.
+- A percent-encoded fragment resolves to the generated anchor.
+- Query strings do not affect target or fragment resolution.
+- An SVG fragment and an HTTPS link remain outside Markdown heading validation.
+- Missing and repository-escaping files retain their existing failure messages
+  without an additional anchor error.
+
+**Verification:** The focused suite distinguishes file-target failures from
+fragment-target failures and preserves all existing regressions.
+
+### U3. Integrate mutation-sensitive evidence and guidance
+
+**Goal:** Make the new boundary durable in the full repository gate.
+
+**Requirements:** R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+
+- `scripts/check-baseline.sh`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `docs/plans/2026-06-16-markdown-heading-fragment-integrity.md`
+
+**Approach:** Extend the static baseline contract with the new anchor failure,
+focused test, guidance, and completed-plan evidence. Update maintained guidance
+to state that offline verification covers local Markdown heading fragments
+without requesting external URLs.
+
+**Test scenarios:**
+
+- Removing heading-fragment validation fails the baseline.
+- Removing duplicate-heading coverage, same-document coverage, or the completed
+  plan evidence fails the baseline.
+- Repository-root and external-directory verification both exercise the same
+  checker and tests.
+
+**Verification:** Focused mutations are rejected, all Make targets pass, and
+the plan records the exact validation actually completed.
+
+## Risks And Dependencies
+
+- GitHub documents basic anchor-generation rules but its renderer has broader
+  Markdown behavior; the implementation must avoid claiming unsupported parser
+  fidelity.
+- Duplicate suffixes are order-sensitive, so heading extraction must preserve
+  document order and ignore fenced examples.
+- The checker must not turn external availability into a build dependency.
+
+## Sources And Research
+
+- GitHub Docs, "Basic writing and formatting syntax," sections on heading,
+  section-link, relative-link, and custom-anchor behavior:
+  <https://docs.github.com/en/enterprise-cloud@latest/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax>
+- Existing implementation and regressions in `scripts/check-internal-links.py`
+  and `scripts/test-internal-links.py`.
+- Deferred heading-anchor boundary in
+  `docs/plans/2026-06-16-offline-internal-link-integrity.md`.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -23,6 +23,7 @@ MAKE_ROOT_PROTECTION_PLAN="$ROOT_DIR/docs/plans/2026-06-14-make-root-override-pr
 CANONICAL_ALLERGEN_SOURCE_PLAN="$ROOT_DIR/docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md"
 PYTHON_PREFLIGHT_PLAN="$ROOT_DIR/docs/plans/2026-06-16-python-verification-preflight.md"
 INTERNAL_LINK_PLAN="$ROOT_DIR/docs/plans/2026-06-16-offline-internal-link-integrity.md"
+HEADING_FRAGMENT_PLAN="$ROOT_DIR/docs/plans/2026-06-16-markdown-heading-fragment-integrity.md"
 INTERNAL_LINK_CHECKER="$ROOT_DIR/scripts/check-internal-links.py"
 INTERNAL_LINK_TEST="$ROOT_DIR/scripts/test-internal-links.py"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
@@ -75,6 +76,7 @@ for path in \
   "docs/plans/2026-06-14-002-security-canonical-fda-allergen-source-plan.md" \
   "docs/plans/2026-06-16-python-verification-preflight.md" \
   "docs/plans/2026-06-16-offline-internal-link-integrity.md" \
+  "docs/plans/2026-06-16-markdown-heading-fragment-integrity.md" \
   "docs/plans/2026-06-09-no-scaffold-contract.md" \
   "docs/plans/2026-06-10-hosted-content-checks.md" \
   "scripts/check-internal-links.py" \
@@ -90,11 +92,19 @@ if [ "$(grep -Fxc '"$PYTHON" "$INTERNAL_LINK_TEST"' "$ROOT_DIR/scripts/check-bas
   ! grep -Fq 'def validate_repository(root: Path) -> list[str]:' "$INTERNAL_LINK_CHECKER" ||
   ! grep -Fq 'local link escapes repository' "$INTERNAL_LINK_CHECKER" ||
   ! grep -Fq 'local link target does not exist' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'def markdown_anchors(content: str) -> set[str]:' "$INTERNAL_LINK_CHECKER" ||
+  ! grep -Fq 'local Markdown anchor does not exist' "$INTERNAL_LINK_CHECKER" ||
   ! grep -Fq 'if parsed.scheme or parsed.netloc:' "$INTERNAL_LINK_CHECKER" ||
   ! grep -Fq 'test_rejects_missing_local_target' "$INTERNAL_LINK_TEST" ||
   ! grep -Fq 'test_rejects_repository_escape' "$INTERNAL_LINK_TEST" ||
   ! grep -Fq 'test_ignores_links_inside_fenced_examples' "$INTERNAL_LINK_TEST" ||
   ! grep -Fq 'test_ignores_link_syntax_inside_inline_code' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_generates_unique_github_style_heading_anchors' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_rejects_missing_same_and_cross_document_anchors' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_ignores_heading_syntax_inside_fenced_examples' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_ignores_links_and_anchors_inside_html_comments' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_inline_comment_marker_does_not_hide_following_heading' "$INTERNAL_LINK_TEST" ||
+  ! grep -Fq 'test_ignores_custom_anchor_syntax_inside_inline_code' "$INTERNAL_LINK_TEST" ||
   ! grep -Fq 'test_rejects_missing_reference_definition_target' "$INTERNAL_LINK_TEST"; then
   printf '%s\n' "Offline internal-link verification contracts are incomplete." >&2
   exit 1
@@ -775,7 +785,7 @@ for python_preflight_plan_contract in \
   fi
 done
 
-internal_link_guidance='Offline verification checks relative Markdown link and image targets without requesting external URLs.'
+internal_link_guidance='Offline verification checks relative Markdown link, image, and heading-fragment targets without requesting external URLs.'
 for internal_link_doc in README.md SECURITY.md VISION.md CHANGES.md; do
   if ! grep -Fq "$internal_link_guidance" "$ROOT_DIR/$internal_link_doc"; then
     printf '%s\n' "$internal_link_doc must document offline internal-link verification." >&2
@@ -790,6 +800,18 @@ for internal_link_plan_contract in \
   "No external URL request"; do
   if ! grep -Fq "$internal_link_plan_contract" "$INTERNAL_LINK_PLAN"; then
     printf '%s\n' "Offline internal-link plan must record completed evidence: $internal_link_plan_contract" >&2
+    exit 1
+  fi
+done
+
+for heading_fragment_plan_contract in \
+  "## Status: Completed" \
+  "## Verification Completed" \
+  "14 focused temporary-tree regressions" \
+  "14 isolated heading-fragment mutations were rejected" \
+  "No external URL request"; do
+  if ! grep -Fq "$heading_fragment_plan_contract" "$HEADING_FRAGMENT_PLAN"; then
+    printf '%s\n' "Heading-fragment plan must record completed evidence: $heading_fragment_plan_contract" >&2
     exit 1
   fi
 done

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -809,6 +809,9 @@ for heading_fragment_plan_contract in \
   "## Verification Completed" \
   "14 focused temporary-tree regressions" \
   "14 isolated heading-fragment mutations were rejected" \
+  'Push run `27629257088`' \
+  'pull-request run `27629271024`' \
+  '`99e86701f69cfdfbe9c6134d5bcda5767ada2cea`' \
   "No external URL request"; do
   if ! grep -Fq "$heading_fragment_plan_contract" "$HEADING_FRAGMENT_PLAN"; then
     printf '%s\n' "Heading-fragment plan must record completed evidence: $heading_fragment_plan_contract" >&2

--- a/scripts/check-internal-links.py
+++ b/scripts/check-internal-links.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import html
 import re
 import sys
+import unicodedata
 from pathlib import Path
 from urllib.parse import unquote, urlsplit
 
@@ -14,6 +16,16 @@ LINK_PATTERN = re.compile(
 REFERENCE_PATTERN = re.compile(
     r"^\s{0,3}\[[^\]]+\]:\s*(?P<destination><[^>]+>|\S+)"
 )
+ATX_HEADING_PATTERN = re.compile(r"^\s{0,3}#{1,6}(?:[ \t]+|$)(?P<text>.*)$")
+SETEXT_HEADING_PATTERN = re.compile(r"^\s{0,3}(?:=+|-+)[ \t]*$")
+CUSTOM_ANCHOR_PATTERN = re.compile(
+    r"<a\s+[^>]*\bname\s*=\s*(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)')[^>]*>",
+    re.IGNORECASE,
+)
+INLINE_LINK_PATTERN = re.compile(r"!?\[([^\]]*)\]\([^)]*\)")
+REFERENCE_LINK_PATTERN = re.compile(r"!?\[([^\]]*)\]\[[^\]]*\]")
+CODE_SPAN_PATTERN = re.compile(r"(`+)(.*?)\1")
+HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 
 
 def is_within_root(path: Path, root: Path) -> bool:
@@ -28,6 +40,41 @@ def markdown_files(root: Path):
     for path in sorted(root.rglob("*.md")):
         if ".git" not in path.parts:
             yield path
+
+
+def visible_markdown_lines(content: str):
+    in_fence = False
+    in_comment = False
+    for line_number, line in enumerate(content.splitlines(), 1):
+        if not in_fence:
+            visible_parts = []
+            position = 0
+            comment_search = without_code_spans(line)
+            while position < len(line):
+                if in_comment:
+                    comment_end = line.find("-->", position)
+                    if comment_end < 0:
+                        position = len(line)
+                        continue
+                    in_comment = False
+                    position = comment_end + 3
+                    continue
+
+                comment_start = comment_search.find("<!--", position)
+                if comment_start < 0:
+                    visible_parts.append(line[position:])
+                    break
+                visible_parts.append(line[position:comment_start])
+                in_comment = True
+                position = comment_start + 4
+            line = "".join(visible_parts)
+
+        stripped = line.lstrip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            yield line_number, line
 
 
 def without_code_spans(line: str) -> str:
@@ -62,32 +109,98 @@ def destinations(line: str):
         yield reference.group("destination")
 
 
+def plain_heading_text(text: str) -> str:
+    text = re.sub(r"[ \t]+#+[ \t]*$", "", text)
+    text = CODE_SPAN_PATTERN.sub(lambda match: match.group(2), text)
+    text = INLINE_LINK_PATTERN.sub(lambda match: match.group(1), text)
+    text = REFERENCE_LINK_PATTERN.sub(lambda match: match.group(1), text)
+    text = HTML_TAG_PATTERN.sub("", text)
+    text = html.unescape(text)
+    text = re.sub(r"\\(.)", r"\1", text)
+    return text.replace("*", "").replace("_", "").replace("~", "")
+
+
+def github_heading_slug(text: str) -> str:
+    slug = []
+    for character in plain_heading_text(text).strip().lower():
+        if character == " ":
+            slug.append("-")
+        elif character.isspace():
+            continue
+        elif unicodedata.category(character).startswith("P") and character != "-":
+            continue
+        else:
+            slug.append(character)
+    return "".join(slug)
+
+
+def markdown_anchors(content: str) -> set[str]:
+    anchors: set[str] = set()
+    generated: set[str] = set()
+    previous_heading_candidate: str | None = None
+
+    def add_heading(text: str) -> None:
+        base = github_heading_slug(text)
+        if not base:
+            return
+
+        candidate = base
+        suffix = 0
+        while candidate in generated:
+            suffix += 1
+            candidate = f"{base}-{suffix}"
+        generated.add(candidate)
+        anchors.add(candidate)
+
+    for _, line in visible_markdown_lines(content):
+        for match in CUSTOM_ANCHOR_PATTERN.finditer(without_code_spans(line)):
+            anchors.add(match.group("double") or match.group("single"))
+
+        atx_heading = ATX_HEADING_PATTERN.match(line)
+        if atx_heading:
+            add_heading(atx_heading.group("text"))
+            previous_heading_candidate = None
+            continue
+
+        if SETEXT_HEADING_PATTERN.match(line) and previous_heading_candidate is not None:
+            add_heading(previous_heading_candidate)
+            previous_heading_candidate = None
+            continue
+
+        previous_heading_candidate = line if line.strip() else None
+
+    return anchors
+
+
 def validate_repository(root: Path) -> list[str]:
     root = root.resolve()
     failures: list[str] = []
+    anchor_cache: dict[Path, set[str]] = {}
+
+    def anchors_for(path: Path) -> set[str]:
+        if path not in anchor_cache:
+            anchor_cache[path] = markdown_anchors(path.read_text(encoding="utf-8"))
+        return anchor_cache[path]
 
     for source in markdown_files(root):
-        in_fence = False
-        for line_number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
-            stripped = line.lstrip()
-            if stripped.startswith("```") or stripped.startswith("~~~"):
-                in_fence = not in_fence
-                continue
-            if in_fence:
-                continue
-
+        content = source.read_text(encoding="utf-8")
+        for line_number, line in visible_markdown_lines(content):
             for raw_destination in destinations(line):
                 destination = raw_destination.strip("<>")
-                if destination.startswith("#") or destination.startswith("//"):
+                if destination.startswith("//"):
                     continue
 
                 parsed = urlsplit(destination)
                 if parsed.scheme or parsed.netloc:
                     continue
-                if not parsed.path or parsed.path.startswith("/"):
+                if parsed.path.startswith("/"):
                     continue
 
-                target = (source.parent / unquote(parsed.path)).resolve()
+                target = (
+                    source
+                    if not parsed.path
+                    else (source.parent / unquote(parsed.path)).resolve()
+                )
                 location = f"{source.relative_to(root)}:{line_number}"
                 if not is_within_root(target, root):
                     failures.append(
@@ -97,6 +210,12 @@ def validate_repository(root: Path) -> list[str]:
                     failures.append(
                         f"{location}: local link target does not exist: {destination}"
                     )
+                elif parsed.fragment and target.suffix.lower() == ".md":
+                    fragment = unquote(parsed.fragment)
+                    if fragment not in anchors_for(target):
+                        failures.append(
+                            f"{location}: local Markdown anchor does not exist: {destination}"
+                        )
 
     return failures
 

--- a/scripts/test-internal-links.py
+++ b/scripts/test-internal-links.py
@@ -32,6 +32,7 @@ class InternalLinkChecks(unittest.TestCase):
         failures = self.validate(
             {
                 "README.md": (
+                    "# Section\n"
                     "[Guide](docs/guide.md?view=1#intro)\n"
                     "![Overview](docs/overview.svg)\n"
                     "[Section](#section)\n"
@@ -45,15 +46,154 @@ class InternalLinkChecks(unittest.TestCase):
         )
         self.assertEqual(failures, [])
 
+    def test_generates_unique_github_style_heading_anchors(self):
+        anchors = CHECKER.markdown_anchors(
+            "## Repeat\n"
+            "## Repeat\n"
+            "## Repeat-1\n"
+            "## *Helpful* [Link](https://example.com) `Code`!\n"
+            "Setext Section\n"
+            "--------------\n"
+            "```markdown\n"
+            "# Hidden\n"
+            "```\n"
+            "<a name='serving-note'></a>\n"
+        )
+        self.assertEqual(
+            anchors,
+            {
+                "repeat",
+                "repeat-1",
+                "repeat-1-1",
+                "helpful-link-code",
+                "setext-section",
+                "serving-note",
+            },
+        )
+
+    def test_accepts_generated_and_custom_markdown_anchors(self):
+        failures = self.validate(
+            {
+                "README.md": (
+                    "# Local Section\n"
+                    "[Local](#local-section)\n"
+                    "[Formatted](docs/guide.md#helpful-link-code)\n"
+                    "[Setext](docs/guide.md#setext-section)\n"
+                    "[Duplicate](docs/guide.md#repeat-1)\n"
+                    "[Collision](docs/guide.md#repeat-1-1)\n"
+                    "[Custom](docs/guide.md#serving-note)\n"
+                    "[Encoded](docs/guide.md#caf%C3%A9-notes)\n"
+                ),
+                "docs/guide.md": (
+                    "## *Helpful* [Link](https://example.com) `Code`!\n"
+                    "\n"
+                    "Setext Section\n"
+                    "--------------\n"
+                    "\n"
+                    "## Repeat\n"
+                    "## Repeat\n"
+                    "## Repeat-1\n"
+                    "<a name=\"serving-note\"></a>\n"
+                    "## Café Notes\n"
+                ),
+            }
+        )
+        self.assertEqual(failures, [])
+
+    def test_rejects_missing_same_and_cross_document_anchors(self):
+        failures = self.validate(
+            {
+                "README.md": (
+                    "# Existing\n"
+                    "[Missing local](#missing)\n"
+                    "[Missing remote](docs/guide.md#missing)\n"
+                ),
+                "docs/guide.md": "# Existing\n",
+            }
+        )
+        self.assertEqual(len(failures), 2)
+        self.assertTrue(
+            all("local Markdown anchor does not exist" in failure for failure in failures)
+        )
+
+    def test_ignores_heading_syntax_inside_fenced_examples(self):
+        failures = self.validate(
+            {
+                "README.md": "[Hidden](docs/guide.md#hidden)\n",
+                "docs/guide.md": "```markdown\n# Hidden\n```\n",
+            }
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertIn("local Markdown anchor does not exist", failures[0])
+
+    def test_ignores_links_and_anchors_inside_html_comments(self):
+        failures = self.validate(
+            {
+                "README.md": (
+                    "<!-- [Ignored](docs/missing.md) -->\n"
+                    "[Hidden](docs/guide.md#hidden)\n"
+                    "[Comment anchor](docs/guide.md#comment-anchor)\n"
+                ),
+                "docs/guide.md": (
+                    "<!--\n"
+                    "# Hidden\n"
+                    "<a name='comment-anchor'></a>\n"
+                    "-->\n"
+                ),
+            }
+        )
+        self.assertEqual(len(failures), 2)
+        self.assertTrue(
+            all("local Markdown anchor does not exist" in failure for failure in failures)
+        )
+
+    def test_inline_comment_marker_does_not_hide_following_heading(self):
+        failures = self.validate(
+            {
+                "README.md": (
+                    "Use `<!--` when documenting a comment opener.\n"
+                    "# Visible Section\n"
+                    "[Visible](#visible-section)\n"
+                ),
+                "docs/index.md": "[Visible](../README.md#visible-section)\n",
+            }
+        )
+        self.assertEqual(failures, [])
+
+    def test_ignores_custom_anchor_syntax_inside_inline_code(self):
+        failures = self.validate(
+            {
+                "README.md": "[Example](docs/guide.md#example-anchor)\n",
+                "docs/guide.md": (
+                    "Use `<a name='example-anchor'></a>` as sample syntax.\n"
+                ),
+            }
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertIn("local Markdown anchor does not exist", failures[0])
+
+    def test_skips_fragments_for_non_markdown_targets(self):
+        failures = self.validate(
+            {
+                "README.md": "![Overview](docs/overview.svg#diagram)\n",
+                "docs/overview.svg": "<svg/>\n",
+            }
+        )
+        self.assertEqual(failures, [])
+
     def test_rejects_missing_local_target(self):
-        failures = self.validate({"README.md": "![Overview](docs/missing.svg)\n"})
+        failures = self.validate(
+            {"README.md": "[Guide](docs/missing.md#section)\n"}
+        )
         self.assertEqual(len(failures), 1)
         self.assertIn("local link target does not exist", failures[0])
+        self.assertNotIn("Markdown anchor", failures[0])
 
     def test_rejects_repository_escape(self):
-        failures = self.validate({"README.md": "[Outside](../outside.md)\n"})
+        failures = self.validate({"README.md": "[Outside](../outside.md#section)\n"})
         self.assertEqual(len(failures), 1)
         self.assertIn("local link escapes repository", failures[0])
+        self.assertNotIn("Markdown anchor", failures[0])
 
     def test_ignores_links_inside_fenced_examples(self):
         failures = self.validate(


### PR DESCRIPTION
## Summary

Local Markdown links can no longer point to a file that exists while silently targeting a missing section. The offline content gate now resolves same-document and cross-document fragments against GitHub-style heading anchors and explicit custom anchors without making network requests.

## Baseline

The existing checker validated relative file targets but intentionally ignored URL fragments. A heading rename, duplicate-heading reorder, or typo such as `pancakes.md#missing-section` therefore remained green even though GitHub navigation was broken.

## Improvements

- Indexes ATX and setext headings with GitHub's documented lowercase, formatting, punctuation, whitespace, and duplicate-suffix behavior.
- Resolves percent-encoded fragments and explicit `<a name="...">` anchors while keeping custom anchors separate from heading duplicate numbering.
- Ignores fenced examples, HTML comments, inline comment markers, and custom-anchor examples shown as inline code.
- Caches each Markdown target's anchor set and preserves existing missing-target, repository-escape, external-link, and non-Markdown fragment behavior.
- Pins the completed plan to implementation head `99e86701f69cfdfbe9c6134d5bcda5767ada2cea`, push run `27629257088`, and pull-request run `27629271024`.

## Validation

- `sh -n scripts/check-baseline.sh`
- Python compilation and 14 focused temporary-tree regressions
- `make check`, `make lint`, `make test`, and `make build`
- Absolute-Makefile `check` from an external working directory
- 14 isolated implementation mutations rejected
- Four evidence-contract mutations covering status, implementation head, push run, and pull-request run rejected
- Final artifact, whitespace, and changed-line credential audits passed
- Exact evidence head `fe6a50493b420685ea9c34d1a927328f03a5cc6f` passed pull-request runs `27696840073` and `27696845974`

## Risk

The parser intentionally implements GitHub's documented basic anchor rules rather than full CommonMark rendering. Multiline links, arbitrary raw-HTML element IDs, browser rendering, and external URL health remain outside the deterministic offline gate.

This PR is stacked on open PR #13 and must retain base-first merge ordering. Neither PR should be merged or closed without explicit authorization. Any new `local Markdown anchor does not exist` failure should block integration until its target fragment is corrected.

## Follow-Ups

- Revisit full renderer fidelity only when a concrete maintained Markdown construct is not covered by the dependency-free parser.
- Keep external URL availability outside the offline build gate.
- No deployed runtime monitoring is required; retain both exact-head `check` results as the integration gate.
